### PR TITLE
perf(ce): Limit GSEControl querry to parent

### DIFF
--- a/packages/core/src/scd/scd-query.ts
+++ b/packages/core/src/scd/scd-query.ts
@@ -89,9 +89,9 @@ export class SCDQueries {
 		)
 	}
 
-	public searchGSEControlByIEDNameAndName(iedName: string, cbName: string, options?:CommonOptions): GSEControlElement {
+	public searchGSEControlByName(cbName: string, options?:CommonOptions): GSEControlElement {
 		return this.searchElement<GSEControlElement>(
-			`SCL > IED[name='${iedName}'] GSEControl[name='${cbName}']`,
+			`${SCDQueries.SelectorGSEControl}[name='${cbName}']`,
 			["name", "datSet"],
 			options,
 		)[0]

--- a/packages/core/src/scd/scd-query.ts
+++ b/packages/core/src/scd/scd-query.ts
@@ -526,7 +526,7 @@ export type InputExtRefElement = SCDElement & {
 }
 
 export type InputExtRefElementWithDatSet = InputExtRefElement & {
-	datSet: string
+	datSet: string | null
 }
 
 // <ConnectedAP apName="F" iedName="AARSC_CcC_1101" redProt="prp">

--- a/packages/core/src/use-cases/uc-communication-information.ts
+++ b/packages/core/src/use-cases/uc-communication-information.ts
@@ -19,7 +19,7 @@ export class UCCommunicationInformation {
 				iedName:   ied.name,
 				// published: this.findPublishedMessages(ied),
 				published: this.findPublishedMessages_V2(ied),
-				received:  this.findReceivedMessages(ied),
+				received:  this.findReceivedMessages(ied, ieds),
 			}
 		})
 		return commInfos
@@ -153,13 +153,24 @@ export class UCCommunicationInformation {
 	// 	return published
 	// }
 
-	private findReceivedMessages(ied: IEDElement ): ReceivedMessage[] {
+	private findReceivedMessages(ied: IEDElement, allIeds: IEDElement[]): ReceivedMessage[] {
 		const inputs = this.scdQueries.searchInputs({ root: ied.element })
 		const extRefs = inputs.map(input => this.scdQueries.searchExtRef({ root: input.element })).flat()
 
 		const extRefsWithConnectionID = extRefs.map((el) => {
 			const srcCBName = el.srcCBName
-			const connection = this.scdQueries.searchGSEControlByName(srcCBName, {root: ied.element})
+			const iedName = el.iedName
+			const parentIed = allIeds.find(i => i.name === iedName)
+
+			if (!parentIed) {
+				const newInput: InputExtRefElementWithDatSet = {
+					...el,
+					datSet: null,
+				}
+				return newInput
+			}
+
+			const connection = this.scdQueries.searchGSEControlByName(srcCBName, {root: parentIed?.element})
 			const datSet = connection?.datSet
 
 			const newInput: InputExtRefElementWithDatSet = {

--- a/packages/core/src/use-cases/uc-communication-information.ts
+++ b/packages/core/src/use-cases/uc-communication-information.ts
@@ -158,9 +158,8 @@ export class UCCommunicationInformation {
 		const extRefs = inputs.map(input => this.scdQueries.searchExtRef({ root: input.element })).flat()
 
 		const extRefsWithConnectionID = extRefs.map((el) => {
-			const iedName = el.iedName
 			const srcCBName = el.srcCBName
-			const connection = this.scdQueries.searchGSEControlByIEDNameAndName(iedName, srcCBName)
+			const connection = this.scdQueries.searchGSEControlByName(srcCBName, {root: ied.element})
 			const datSet = connection?.datSet
 
 			const newInput: InputExtRefElementWithDatSet = {


### PR DESCRIPTION
GSEControl querry unnecessarily searched the entire document instead of its parent IED

Closes #40, #42