### PR TITLE
separate subscriber and publisher

### DIFF
--- a/packages/uilib/src/lib/components/accordion/publisher-subscriber-accordion/publisher-subscriber-accordion.svelte
+++ b/packages/uilib/src/lib/components/accordion/publisher-subscriber-accordion/publisher-subscriber-accordion.svelte
@@ -11,16 +11,24 @@
     export let color: string
     export let connectionDirection: ConnectionTypeDirection
 
-    $: affectedIEDs = affectedIEDObjects.map((el) => {
-    	return el.node
-    })
+    $: affectedSubscriberIEDs = affectedIEDObjects
+        .filter(
+            (el) => el.connectionDirection === ConnectionTypeDirection.INCOMING,
+        )
+        .map((el) => el.node);
+
+    $: affectedPublisherIEDs = affectedIEDObjects
+        .filter(
+            (el) => el.connectionDirection === ConnectionTypeDirection.OUTGOING,
+        )
+        .map((el) => el.node);
 
     $: iconName = calcIconName(serviceType, connectionDirection)
 
     function calcIconName(serviceType: string, connectionDirection: ConnectionTypeDirection): OpenSCDIconNames {
     	let serviceTypeShort = ""
     	let serviceTypeDirection = ""
-        
+
     	if (serviceType === "GOOSE") 
     		serviceTypeShort = "goose"
     	else if (serviceType === "SampledValues")
@@ -30,7 +38,7 @@
     	else
     		serviceTypeShort = "undefined"
 
-    	if (connectionDirection === ConnectionTypeDirection.INCOMING) 
+        if (connectionDirection === ConnectionTypeDirection.INCOMING)
     		serviceTypeDirection = "Incoming"
     	else 
     		serviceTypeDirection = "Outgoing"
@@ -60,19 +68,34 @@
             </div>
 
             <hr class="seperation-line" />
-            {#if affectedIEDs.length > 0}
-                <ul>
-                    Subscribers
-                    {#each affectedIEDs as ied}
-                        <li>
-                            <div class="ied-component">
-                                {ied.label}
-                            </div>
-                        </li>
-                    {/each}
-                </ul>
-            {:else}
+            {#if affectedSubscriberIEDs.length + affectedPublisherIEDs.length == 0}
                 <p>No items found</p>
+            {:else}
+                {#if affectedSubscriberIEDs.length > 0}
+                    <ul>
+                        Subscribers
+                        {#each affectedSubscriberIEDs as ied}
+                            <li>
+                                <div class="ied-component">
+                                    {ied.label}
+                                </div>
+                            </li>
+                        {/each}
+                    </ul>
+                {/if}
+
+                {#if affectedPublisherIEDs.length > 0}
+                    <ul>
+                        Publishers
+                        {#each affectedPublisherIEDs as ied}
+                            <li>
+                                <div class="ied-component">
+                                    {ied.label}
+                                </div>
+                            </li>
+                        {/each}
+                    </ul>
+                {/if}
             {/if}
         </div>
     </details>


### PR DESCRIPTION
**Issue:** https://github.com/sprinteins/oscd-plugins/issues/50

- [x] Instead of only **"Subscribers"** the sidebar makes a difference between **"Subscribers"** and **"Publishers"** in the title.

old:
![image](https://github.com/user-attachments/assets/1996f8fe-3444-457f-9bd9-7a9d8186b87d)

new:
![image](https://github.com/user-attachments/assets/e8d28ce6-598c-4b1e-81a3-6146337c1477)
