### PR TITLE
feat(type-designer) column collapse

### DIFF
--- a/packages/plugins/type-designer/src/components/elements-type-container/columns.svelte
+++ b/packages/plugins/type-designer/src/components/elements-type-container/columns.svelte
@@ -31,7 +31,7 @@
 <article class="columns-container" id="type-designer-columns">
   {#if columnsStore}
     {#each $columnsStore as column, index}
-      <Paper class="column">
+      <Paper class={`column-${column.visible ? "expanded" : "collapsed"}`}>
         <div class="column-header">
           {#if column.visible}
             <h2>{column.name}</h2>
@@ -81,7 +81,7 @@
     box-sizing: border-box;
   }
 
-  #type-designer-columns :global(.column) {
+  #type-designer-columns :global(.column-expanded) {
     padding: 0;
     display: flex;
     flex-direction: column;
@@ -90,10 +90,31 @@
     width: 100%;
   }
 
+  #type-designer-columns :global(.column-collapsed) {
+    width: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
   #type-designer-columns :global(.column-header) {
     display: flex;
     justify-content: space-between;
     padding: 0.5rem;
+  }
+
+  #type-designer-columns :global(.column-collapsed .column-header) {
+    width: 2rem;
+    height: 100%;
+    flex-direction: column-reverse;
+    align-items: center;
+    padding: 0rem;
+  }
+
+  #type-designer-columns :global(.column-collapsed h2) {
+    transform: rotate(-90deg);
+    transform-origin: center;
+    width: max-content;
   }
 
   #type-designer-columns :global(.content) {

--- a/packages/plugins/type-designer/src/components/elements-type-container/columns.svelte
+++ b/packages/plugins/type-designer/src/components/elements-type-container/columns.svelte
@@ -1,9 +1,9 @@
 <script context="module" lang="ts">
-  export type Column = {
-    name: string;
-    visible: boolean;
-    items: DataTypeTemplates[];
-  };
+export type Column = {
+	name: string
+	visible: boolean
+	items: DataTypeTemplates[]
+}
 </script>
 
 <script lang="ts">
@@ -34,12 +34,13 @@
       <Paper class={`column-${column.visible ? "expanded" : "collapsed"}`}>
         <div class="column-header">
           {#if column.visible}
-            <h2>{column.name}</h2>
+            <h1>{column.name}</h1>
           {:else}
-            <h2>{column.name} (hidden)</h2>
+            <h1>{column.name} (hidden)</h1>
           {/if}
           <IconButton
             on:click={() => columnsStore.toggleColumnVisibility(index)}
+						class="icon-visibility"
           >
             <IconWrapper
               icon={column.visible ? "visibility" : "visibility_off"}
@@ -54,16 +55,18 @@
             </div>
           </Content>
         {/if}
-        <div class="add-button-container">
-          {#if column.visible && column.name !== ELEMENT_NAMES.lNode}
-            <Button
-              class="add-button"
-              on:click={() => columnsStore.addItemToColumn(index)}
-            >
-              + add {column.name}
-            </Button>
-          {/if}
-        </div>
+        
+				{#if column.visible && column.name !== ELEMENT_NAMES.lNode}
+				<div class="add-button-container">
+					<Button
+						class="add-button"
+						on:click={() => columnsStore.addItemToColumn(index)}
+					>
+						+ add {column.name}
+					</Button>
+				</div>
+				{/if}
+
       </Paper>
     {/each}
   {/if}
@@ -73,7 +76,6 @@
   .columns-container {
     display: flex;
     gap: 1rem;
-    justify-content: space-between;
     padding: 1rem;
     height: 100%;
     overflow: hidden;
@@ -91,30 +93,43 @@
   }
 
   #type-designer-columns :global(.column-collapsed) {
-    width: 20px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+		display: flex;
+    justify-content: space-between;
+    padding: 0.5rem;
   }
 
   #type-designer-columns :global(.column-header) {
     display: flex;
     justify-content: space-between;
-    padding: 0.5rem;
+		align-items: center;
+		padding: 0 1rem;
   }
 
   #type-designer-columns :global(.column-collapsed .column-header) {
-    width: 2rem;
-    height: 100%;
-    flex-direction: column-reverse;
-    align-items: center;
-    padding: 0rem;
+		padding: revert;
+		position: relative;
+		display: flex;
+		height: 100%;
+		flex-direction: column;
+		align-items: center;
   }
 
-  #type-designer-columns :global(.column-collapsed h2) {
-    transform: rotate(-90deg);
-    transform-origin: center;
-    width: max-content;
+	h1 {
+		width: max-content;
+	}
+
+  #type-designer-columns :global(.column-collapsed h1) {
+		transform-origin: 0 0;
+		transform: rotate(-90deg);
+		line-height: revert !important;
+		position: absolute;
+		bottom: -1.5rem;
+		left: .75rem;
+		margin: 0;
+  }
+
+	#type-designer-columns :global(.icon-visibility) {
+    margin-top: .25rem;
   }
 
   #type-designer-columns :global(.content) {
@@ -157,16 +172,6 @@
     cursor: pointer;
   }
 
-  #type-designer-columns :global(.rhombus-icon) {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    width: 8px;
-    height: 8px;
-    background-color: rgb(81, 159, 152);
-    transform: rotate(45deg);
-  }
-
   @media (max-width: 768px) {
     .columns-container {
       flex-direction: column;
@@ -177,5 +182,29 @@
       max-width: none;
       height: auto;
     }
+
+		/* COLUMNS COLLAPSE */
+
+
+		#type-designer-columns :global(.column-collapsed .column-header) {
+			padding: inherit;
+			position: relative;
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+			width: 100%;
+		}
+
+		#type-designer-columns :global(.column-collapsed h1) {
+			transform-origin: 0 0;
+			transform: rotate(0deg);
+			line-height: revert !important;
+			position: revert;
+			margin: revert;
+		}
+
+		#type-designer-columns :global(.icon-visibility) {
+    margin-top: revert;
+  }
   }
 </style>

--- a/packages/plugins/type-designer/src/components/elements-type-container/content-card.svelte
+++ b/packages/plugins/type-designer/src/components/elements-type-container/content-card.svelte
@@ -4,17 +4,14 @@
 
     export let elementType: DataTypeTemplates[];
 
-    function handleCardClick(item: string) {
+    function handleCardClick(item: DataTypeTemplates) {
         console.log("Clicked:", item);
     }
 </script>
 
 <section id="type-designer-card">
     {#each elementType as elementType}
-        <Card
-            class="card"
-            on:click={() => handleCardClick(JSON.stringify(elementType))}
-        >
+        <Card class="card" on:click={() => handleCardClick(elementType)}>
             {elementType.name}
             <div class="rhombus-icon"></div>
         </Card>
@@ -24,7 +21,6 @@
 <style>
     #type-designer-card :global(.card) {
         padding: 1rem;
-        background-color: #f5f5f5;
         border-radius: 4px;
         margin-bottom: 1rem;
         flex-shrink: 0;

--- a/packages/plugins/type-designer/src/plugin.svelte
+++ b/packages/plugins/type-designer/src/plugin.svelte
@@ -6,7 +6,6 @@
 
 <script lang="ts">
 	// STYLES
-	// TODO
 	// import pluginUrl from './style.css?url'
 	// COMPONENTS
 	import { MaterialTheme } from "@oscd-plugins/ui";
@@ -17,7 +16,6 @@
 	import { dataTypeTemplatesStore, pluginStore } from "./stores";
 
 	const baseURL = new URL(import.meta.url);
-	// TODO
 	// const pluginCss = new URL(pluginUrl, baseURL).href
 
 	//==== INITIALIZATION ====//
@@ -35,7 +33,6 @@
 </script>
 
 <!-- Link tags are allowed at root of a shadow dom -->
-// TODO
 <!-- <link rel="stylesheet" href={pluginCss} /> -->
 <!-- Plugin logs -->
 <input type="hidden" name="package-name" value={jsonPackage.name} />


### PR DESCRIPTION
Hide/Display Column Feature with Eye Icon
As a User
I want to hide or display a given column using an eye icon
So that I can manage the visibility of columns and keep the interface clean and focused on the relevant information.

Acceptance Criteria:

- [x] Each column should have an eye icon next to its header.
- [x] Clicking the eye icon should hide the column and compact it to the side with just the title visible.
- [x] The compacted column should display the title vertically on the side.
- [x] Clicking the eye icon again should display the column back to its original state.

Current Implementation:

<img width="1834" alt="image" src="https://github.com/user-attachments/assets/28a51eaf-4cb3-4d97-b645-947d488ddd4f">
