### PR TITLE
feat(type-designer): [SPIKE] [Existing code rebased] Add DND Integration

### DIFF
--- a/packages/plugins/type-designer/package.json
+++ b/packages/plugins/type-designer/package.json
@@ -22,7 +22,8 @@
 		"@smui/icon-button": "7.0.0",
 		"@smui/layout-grid": "7.0.0",
 		"@smui/paper": "7.0.0",
-		"@smui/textfield": "7.0.0"
+		"@smui/textfield": "7.0.0",
+		"svelte-dnd-action": "^0.9.52"
 	},
 	"devDependencies": {
 		"@sveltejs/vite-plugin-svelte": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       '@smui/textfield':
         specifier: 7.0.0
         version: 7.0.0(svelte@4.2.19)(typescript@5.5.4)
+      svelte-dnd-action:
+        specifier: ^0.9.52
+        version: 0.9.52(svelte@4.2.19)
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.1
@@ -582,7 +585,7 @@ importers:
         version: 6.11.0(eslint@8.31.0)(typescript@5.2.2)
       '@vitest/coverage-c8':
         specifier: ^0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        version: 0.30.1(vitest@0.30.1(@vitest/browser@0.29.7)(@vitest/ui@0.30.1)(happy-dom@8.9.0)(jsdom@21.1.1)(playwright@1.48.1)(safaridriver@0.0.4)(sass@1.62.0)(webdriverio@8.6.7(typescript@5.2.2)))
       '@vitest/ui':
         specifier: ^0.30.1
         version: 0.30.1
@@ -5135,6 +5138,11 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
+  svelte-dnd-action@0.9.52:
+    resolution: {integrity: sha512-f841HB5PCcvp21jsMkxSXCXcsJcGmIPMguN6iI1gXqP9Owcb47+ZUIE5ETUzNJntE9h7dm1wFj2Bm51hRtQ7Lw==}
+    peerDependencies:
+      svelte: '>=3.23.0 || ^5.0.0-next.0'
+
   svelte-hmr@0.15.1:
     resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
@@ -8967,7 +8975,7 @@ snapshots:
       vitest: 0.30.1(@vitest/browser@0.29.7)(@vitest/ui@0.30.1)(happy-dom@8.9.0)(jsdom@21.1.1)(playwright@1.48.1)(safaridriver@0.0.4)(sass@1.62.0)(webdriverio@8.6.7(typescript@5.2.2))
     optional: true
 
-  '@vitest/coverage-c8@0.30.1(vitest@0.30.1)':
+  '@vitest/coverage-c8@0.30.1(vitest@0.30.1(@vitest/browser@0.29.7)(@vitest/ui@0.30.1)(happy-dom@8.9.0)(jsdom@21.1.1)(playwright@1.48.1)(safaridriver@0.0.4)(sass@1.62.0)(webdriverio@8.6.7(typescript@5.2.2)))':
     dependencies:
       c8: 7.13.0
       picocolors: 1.0.0
@@ -12146,6 +12154,10 @@ snapshots:
       typescript: 5.5.4
     transitivePeerDependencies:
       - picomatch
+
+  svelte-dnd-action@0.9.52(svelte@4.2.19):
+    dependencies:
+      svelte: 4.2.19
 
   svelte-hmr@0.15.1(svelte@3.55.0):
     dependencies:


### PR DESCRIPTION
Story: Adding DND integration
As a User
I want to be able to drag and drop types from column to column
To make it easier for me to manipulate them.

AC:

- [x] Enable drag and drop functionality
- [x] Allow types to be rearranged in the original column
- [x] Allow types to be moved from the original column to a neighbouring column on the left.

Internal AC:
- [x] Prohibit the user from dropping types into the restricted areas
- [ ] BUG: prevent logic from deleting an element that was placed in a wrong column
- [ ] Adjust DND UI (area color, highlighting etc.)

-----
### Test version

https://github.com/user-attachments/assets/6cc61df4-41f2-4c4d-82d3-1c3991aa6413

