### PR TITLE
fixing accidental accordion class deletion + removing unnecessary css…

### DIFF
--- a/packages/uilib/src/lib/plugins/communication-explorer/sidebar/ied-accordion/ied-accordion.svelte
+++ b/packages/uilib/src/lib/plugins/communication-explorer/sidebar/ied-accordion/ied-accordion.svelte
@@ -31,7 +31,7 @@
     let detailsCollapsed = true;
 </script>
 
-<div class="ied">
+<div>
     <IED label={IEDSelection.label} isSelected={true} isSelectable={false} />
 </div>
 {#if details != null}
@@ -63,7 +63,7 @@
     </button>
 {/if}
 
-<div>
+<div class="accordions">
     {#each serviceTypes as serviceType}
         {@const service = serviceType[1]}
         {@const type = service[0].serviceType}
@@ -91,8 +91,7 @@
 </div>
 
 <style lang="scss">
-    .ied {
-    }
+    
     .accordions {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
#83 accidentally removed the accordion class from the sidebar resulting in wrong spacing between accordion elements.

this PR fixes that.

Also the .ied class of ied-accordion.svelte was made obsolete by #83 so this PR fully removes it