### PR TITLE
adding basic label display to sidebar

### DIFF
--- a/packages/core/src/scd-queries/ied/service.ied.ts
+++ b/packages/core/src/scd-queries/ied/service.ied.ts
@@ -1,4 +1,5 @@
 import { IEDQueries } from './queries.ied'
+import { SCDQueries } from '../scd-query'
 // CONSTANTS
 import { MESSAGE_TYPE } from '@/constants/message.contant'
 // TYPES
@@ -9,9 +10,11 @@ import type { IED } from './types.ied'
 
 export class IEDService {
 	private iedQueries: IEDQueries
+	private scdQueries: SCDQueries
 
 	constructor(private readonly root: Element) {
 		this.iedQueries = new IEDQueries(this.root)
+		this.scdQueries = new SCDQueries(this.root)
 	}
 
 	//====== PUBLIC METHODS
@@ -22,6 +25,7 @@ export class IEDService {
 			return {
 				iedName: ied.name,
 				iedDetails: this.parseDetails(ied.element),
+				bays: this.scdQueries.getBaysByIEDName(ied.name),
 				published: this.findPublishedMessages(ied),
 				received: this.findReceivedMessages(ied, ieds)
 			}

--- a/packages/core/src/scd-queries/ied/types.ied.d.ts
+++ b/packages/core/src/scd-queries/ied/types.ied.d.ts
@@ -17,6 +17,7 @@ export namespace IED {
 	export type CommunicationInfo = {
 		iedName: string
 		iedDetails: Details
+		bays: Set<string>
 		published: PublishedMessage[]
 		received: ReceivedMessage[]
 	}

--- a/packages/uilib/src/lib/components/diagram/nodes.ts
+++ b/packages/uilib/src/lib/components/diagram/nodes.ts
@@ -32,12 +32,13 @@ export type SubnetworkEdge = ElkExtendedEdge & {
 }
 
 export type IEDElkNode = Omit<ElkNode, "edges" | "children"> & {
-	label: string,
+	label: string
 	isRelevant?: boolean
 	isBayNode?: boolean
 	edges?: IEDConnection[]
 	children: IEDElkNode[]
 	details: IED.Details
+	bays: Set<string>
 }
 
 export type BayElkNode = Omit<IEDElkNode, "isBayNode"> & {

--- a/packages/uilib/src/lib/plugins/communication-explorer/_func-layout-calculation/node-layout-ieds.ts
+++ b/packages/uilib/src/lib/plugins/communication-explorer/_func-layout-calculation/node-layout-ieds.ts
@@ -38,7 +38,8 @@ export function generateIEDLayout(
 			label: ied.iedName,
 			isRelevant: isRelevant,
 			children: [],
-			details: ied.iedDetails
+			details: ied.iedDetails,
+			bays: ied.bays
 		}
 	})
 


### PR DESCRIPTION
### 🗒 Description

In the communication explorer sidebar, bay labels are displayed right above the IED. Also works correctly with multiple IEDs selected.
No drop-down / click functionality for now. IEDs are not sorted by bay or treated differently if they are in the same bay.

#
### 📷 Demo screen recording or Screenshots

<img width="1161" alt="Screenshot 2024-12-18 172931" src="https://github.com/user-attachments/assets/1df5ab3b-209f-49a4-ac04-dbd99f383e6b" />
(IED04 has no bay)

# 
### 📋 Checklist

- [x] Ticket-ACs are checked and met
- [ ] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [x] Designated PR Reviewers are set
- [x] Tested by another developer
- [ ] Changelog updated
- [ ] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading )
- [x] All comments in the PR are resolved / answered
#

