### PR TITLE
Fix/type designer eq function behaviour

### DIFF
--- a/packages/plugins/type-designer/src/headless/constants/type-elements.ts
+++ b/packages/plugins/type-designer/src/headless/constants/type-elements.ts
@@ -41,12 +41,11 @@ export const ALLOWED_TARGETS_BY_REF_FAMILY = {
 	bay: [],
 	generalEquipment: [TYPE_FAMILY_MAP.bay],
 	conductingEquipment: [TYPE_FAMILY_MAP.bay],
-	function: [
-		TYPE_FAMILY_MAP.bay,
+	function: [TYPE_FAMILY_MAP.bay],
+	eqFunction: [
 		TYPE_FAMILY_MAP.conductingEquipmentType,
 		TYPE_FAMILY_MAP.generalEquipmentType
 	],
-	eqFunction: [TYPE_FAMILY_MAP.generalEquipmentType],
 	lNode: [TYPE_FAMILY_MAP.functionTemplate]
 } as const
 

--- a/packages/plugins/type-designer/src/headless/stores/dnd.svelte.ts
+++ b/packages/plugins/type-designer/src/headless/stores/dnd.svelte.ts
@@ -81,7 +81,10 @@ class UseDnDStore {
 		if (!this.currentSourceTypeIdOrUuid) throw new Error('No source family')
 
 		if (currentFamily === 'genericFunction') {
-			if (typeElementFamily === TYPE_FAMILY_MAP.conductingEquipmentType)
+			if (
+				typeElementFamily === TYPE_FAMILY_MAP.generalEquipmentType ||
+				typeElementFamily === TYPE_FAMILY_MAP.conductingEquipmentType
+			)
 				currentFamily = REF_FAMILY_MAP.eqFunction
 			else currentFamily = REF_FAMILY_MAP.function
 		}

--- a/packages/plugins/type-designer/src/headless/stores/type-elements/store.svelte.ts
+++ b/packages/plugins/type-designer/src/headless/stores/type-elements/store.svelte.ts
@@ -83,7 +83,7 @@ class UseTypeElementsStore {
 		}
 	})
 
-	getUniqueTypeRefsFunctionIds(family: AvailableTypeFamily) {
+	getUniqueTypeRefsFunctionIds(family: AvailableTypeFamily): string[] {
 		return Array.from(
 			// remove duplicates with a Set
 			new Set(
@@ -101,18 +101,13 @@ class UseTypeElementsStore {
 		const conductingEquipmentTypeRefsFunctionIds =
 			this.getUniqueTypeRefsFunctionIds('conductingEquipmentType')
 
-		// is EqFunction if it is not part of ConductingEquipment or Bay per Definition
-		const eqFunctionsIds = generalEquipmentTypeRefsFunctionIds.filter(
-			(id) =>
-				!conductingEquipmentTypeRefsFunctionIds.includes(id) &&
-				!bayTypeRefsFunctionIds.includes(id)
-		)
-
-		const functionsIds = [
+		// is EqFunction if it is not part of Bay per Definition (checking the ConductingEquipment case)
+		const eqFunctionsIds = [
 			...generalEquipmentTypeRefsFunctionIds,
-			...conductingEquipmentTypeRefsFunctionIds,
-			...bayTypeRefsFunctionIds
-		].filter((id) => !eqFunctionsIds.includes(id))
+			...conductingEquipmentTypeRefsFunctionIds
+		]
+
+		const functionsIds = [...bayTypeRefsFunctionIds]
 
 		return {
 			eqFunctionsIds,
@@ -226,11 +221,7 @@ class UseTypeElementsStore {
 		if (!pluginGlobalStore.xmlDocument) throw new Error('No XML document')
 
 		return {
-			node: createStandardElement<
-				typeof family,
-				typeof pluginLocalStore.currentEdition,
-				typeof pluginLocalStore.currentUnstableRevision
-			>({
+			node: createStandardElement({
 				xmlDocument: pluginGlobalStore.xmlDocument,
 				element: { family },
 				attributes: {
@@ -284,11 +275,7 @@ class UseTypeElementsStore {
 		if (!pluginGlobalStore.xmlDocument) throw new Error('No XML document')
 
 		return {
-			node: createStandardElement<
-				typeof family,
-				typeof pluginLocalStore.currentEdition,
-				typeof pluginLocalStore.currentUnstableRevision
-			>({
+			node: createStandardElement({
 				xmlDocument: pluginGlobalStore.xmlDocument,
 				element: {
 					family,
@@ -361,11 +348,7 @@ class UseTypeElementsStore {
 				]
 			}
 		}
-		const newRefElement = createStandardElement<
-			typeof family,
-			typeof pluginLocalStore.currentEdition,
-			typeof pluginLocalStore.currentUnstableRevision
-		>({
+		const newRefElement = createStandardElement({
 			xmlDocument: pluginGlobalStore.xmlDocument,
 			element: {
 				family


### PR DESCRIPTION
# 🗒 Description

Both Function and EqFunction are unqualified on creation ('genericFunction'). Once assigned to a type as ref, it automatically set the right family (function or eqFunction).

Function should be draggable to Bay type only and EqFunction should be draggable to both Equipments types only.
In the XML file, Function and EqFunction are correctly identified as such.

## 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [ ] Designated PR Reviewers are set
- [ ] Tested by another developer
- [ ] Changelog updated
- [ ] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading )
- [ ] All comments in the PR are resolved / answered

## Related US

Closes #268 

