### PR TITLE
Fix/uilib dependency to core #2

### DIFF
--- a/packages/uilib/package.json
+++ b/packages/uilib/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@material/typography": "^14.0.0",
-		"@oscd-plugins/core": "../core/legacy",
+		"@oscd-plugins/core": "workspace:^",
 		"@smui-extra/accordion": "7.0.0-beta.8",
 		"@smui/button": "7.0.0-beta.8",
 		"@smui/card": "7.0.0-beta.8",

--- a/packages/uilib/package.json
+++ b/packages/uilib/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@material/typography": "^14.0.0",
-		"@oscd-plugins/core": "../core",
+		"@oscd-plugins/core": "../core/legacy",
 		"@smui-extra/accordion": "7.0.0-beta.8",
 		"@smui/button": "7.0.0-beta.8",
 		"@smui/card": "7.0.0-beta.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,8 +670,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       '@oscd-plugins/core':
-        specifier: ../core
-        version: link:../core
+        specifier: workspace:^
+        version: link:../core/legacy
       '@smui-extra/accordion':
         specifier: 7.0.0-beta.8
         version: 7.0.0-beta.8(svelte@3.59.2)(typescript@5.6.3)


### PR DESCRIPTION
# 🗒 Description

Uilib package was using a link to import the core (legacy) package as dependency.
This fix import it as a package from the workspace (and thus consume the build instead of the source).