### PR TITLE
fixing error caused by missing check for invalid bays

### DIFF
--- a/packages/uilib/src/lib/plugins/communication-explorer/sidebar/sidebar.svelte
+++ b/packages/uilib/src/lib/plugins/communication-explorer/sidebar/sidebar.svelte
@@ -59,7 +59,7 @@
         if (bays.includes(searchQuery)) {
             clearIEDSelection()
             for (const node of rootNode.children) {
-                if (node.bays.has(searchQuery)) {
+                if (node.bays && node.bays.has(searchQuery)) {
                     toggleMultiSelectionOfIED(node)
                 }
             }


### PR DESCRIPTION
small fix that sometimes caused an error when selecting bays in the sidebar