### PR TITLE
Fix/UI svelte dark theme leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Network Explorer [Unreleased]
-## Communication Explorer [Unreleased]
 ## Type Switcher [Unreleased]
 ## Documentation [Unreleased]
 
@@ -62,31 +61,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - show selected IEDs and their details (#6)
 - 
 
-
-## Communication Explorer [0.0.30] - 2023-11-14
-
-
-### Changed
-- accordion is now reacting to filtered service types
-
-### Fixed
-- align filter pills correctly
-- sampled values icon publish is missing
-- caching extracted information to improve performance
-
-
-## Communication Explorer [0.0.29] - 2023-07-20
-### Fixed
-- align filter pills correctly
-- show sampled value icon
-
-### Added
-- add service type filter in accordion view
-
-## Communication Explorer [0.0.28] - 2023-07-20
-### Fixed
-- show sampled values icon in sidebar
-
 ## Network Explorer [0.0.15] - 2023-07-20
 ### Fixed
 - replace id with label
@@ -94,14 +68,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Network Explorer [0.0.14] - 2023-07-19
-### Changed
-- changed service-type icons
-
-### Added
-- add serviceType Label
-
-## Communication Explorer [0.0.26] - 2023-07-19
-
 ### Changed
 - changed service-type icons
 
@@ -120,61 +86,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - pdf export works now via new tab (technical)
-
-## Communication Explorer [0.0.25] - 2023-06-23
-
-### Fixed
-- last content of the sidebar was not visible when scrollable
-
-## Communication Explorer [0.0.24] - 2023-06-23
-
-### Added
-- draggable diagram when holding space bar
-- zoomable diagram with mouse wheel (not the best but works)
-
-### Changed
-
-- diagrams are centered
-
-### Fixed
-- MMS messages had the wrong direction
-- deselecting by clicking in empty areas worked only in the SVG
-  now it works in the whole panel
-- irrelevant connections were animated
-- selection were persisted even if the user opened a new file causing
-  an invalid state where everything was irrelevant
-- typo in the sidebar
-- removed misleading color of filter chips when clicked
-- empty section in sidebar
-- unnecessary scrollbar in sidebar
-
-### Added
-
-- groups have icons to show which type they are
-
-### Changed
-
-- long texts indicated with an ellipsis
-- adjusted paddings and margins
-
-### Fix
-
-- selecting a node did not trigger change detection
-
-
-## Communication Explorer [0.0.22] - 2023-06-15
-
-## Added
-- clicking on the background of the diagram will deselect all elements
-- multiple IED selection
-- animated connections to see better the direction of messages
-- toggleable animation
-- MMS messages
-- preferences are persisted in local storage
-
-## Changed
-- new diagram design
-- sidebar has separate sections for focus mode and preferences
 
 ## Dedupe [0.0.11] - 2023-06-07
 
@@ -213,49 +124,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Data Object Type
   - Data Attribute Type
   - Enum Type
-
-## Communication Explorer [0.0.12] - 2023-04-27
-
-### Fixed
-
-- Rename Labels in Sidebar Panel
-
-## Communication Explorer [0.0.11] - 2023-04-26
-
-### Added
-
-- Experiment: hide irrelevant stuff
-- Experiment: search by IED name
-
-## Communication Explorer [0.0.10] - 2023-04-26
-
-### Added
-
-- Added Sampled Value Messages to the Communication Explorer
-- Filter by message type
-
-### Fixed
-
-- fixed flickering of the view in case of any change
-
-## Communication Explorer [0.0.9] - 2023-04-21
-
-### Fixed
-
-- Missing IED definition crashed the plugin.
-  It ignores the IED connection has a undefined IED.
-
-## Communication Explorer [0.0.8] - 2023-04-20
-
-### Added
-
-- IEDs are selectable
-- Selecting an IED will show only relevant IEDs and connections
-- Filter for incoming and outgoing connections
-
-### Fixed
-
-- The SVG no grows with the diagram
 
 ### Network Explorer [0.0.9] - 2023-05-23
 

--- a/packages/core/ui-svelte/package.json
+++ b/packages/core/ui-svelte/package.json
@@ -64,7 +64,6 @@
 		"embla-carousel-svelte": "^8.5.1",
 		"formsnap": "2.0.0-next.1",
 		"lucide-svelte": "^0.474.0",
-		"mode-watcher": "^0.5.0",
 		"paneforge": "1.0.0-next.1",
 		"publint": "^0.2.0",
 		"storybook": "^8.4.7",

--- a/packages/core/ui-svelte/src/lib/ui/shadcn/sonner/sonner.svelte
+++ b/packages/core/ui-svelte/src/lib/ui/shadcn/sonner/sonner.svelte
@@ -1,20 +1,29 @@
 <script lang="ts">
-	import { Toaster as Sonner, type ToasterProps as SonnerProps } from "svelte-sonner";
-	import { mode } from "mode-watcher";
+import {
+	Toaster as Sonner,
+	type ToasterProps as SonnerProps
+} from 'svelte-sonner'
 
-	let restProps: SonnerProps = $props();
+let {
+	mode = 'light',
+	...restProps
+}: {
+	mode: 'light' | 'dark' | 'system' | undefined
+	restProps: SonnerProps
+} = $props()
 </script>
-
-<Sonner
-	theme={$mode}
-	class="toaster group"
-	toastOptions={{
-		classes: {
-			toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-			description: "group-[.toast]:text-muted-foreground",
-			actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
-			cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
-		},
-	}}
-	{...restProps}
-/>
+	
+	<Sonner
+		theme={mode}
+		class="toaster group"
+		toastOptions={{
+			classes: {
+				toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+				description: "group-[.toast]:text-muted-foreground",
+				actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+				cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+			},
+		}}
+		{...restProps}
+	/>
+	

--- a/packages/plugins/communication-explorer/CHANGELOG.md
+++ b/packages/plugins/communication-explorer/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to the communication explorer plugin will be documented here
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project should adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-no version numbers are used for now, refer to git history for an overview of previous versions
 
-## 12-02-2025
+## [0.0.32] 26-02-2025
+
+## Changed
+
+- revert theme color fix (dark theme)
+
+## [0.0.31] 12-02-2025
 
 ### Added
 
@@ -15,3 +20,133 @@ no version numbers are used for now, refer to git history for an overview of pre
 ### Changed
 
 - filter dropdown + searchbar are now combined
+
+## [0.0.30] - 2023-11-14
+
+
+### Changed
+- accordion is now reacting to filtered service types
+
+### Fixed
+- align filter pills correctly
+- sampled values icon publish is missing
+- caching extracted information to improve performance
+
+
+## [0.0.29] - 2023-07-20
+### Fixed
+- align filter pills correctly
+- show sampled value icon
+
+### Added
+- add service type filter in accordion view
+
+## [0.0.28] - 2023-07-20
+### Fixed
+- show sampled values icon in sidebar
+
+## [0.0.26] - 2023-07-19
+
+### Changed
+- changed service-type icons
+
+### Added
+- add serviceType Label
+
+## [0.0.25] - 2023-06-23
+
+### Fixed
+- last content of the sidebar was not visible when scrollable
+
+## [0.0.24] - 2023-06-23
+
+### Added
+- draggable diagram when holding space bar
+- zoomable diagram with mouse wheel (not the best but works)
+
+### Changed
+
+- diagrams are centered
+
+### Fixed
+- MMS messages had the wrong direction
+- deselecting by clicking in empty areas worked only in the SVG
+  now it works in the whole panel
+- irrelevant connections were animated
+- selection were persisted even if the user opened a new file causing
+  an invalid state where everything was irrelevant
+- typo in the sidebar
+- removed misleading color of filter chips when clicked
+- empty section in sidebar
+- unnecessary scrollbar in sidebar
+
+### Added
+
+- groups have icons to show which type they are
+
+### Changed
+
+- long texts indicated with an ellipsis
+- adjusted paddings and margins
+
+### Fix
+
+- selecting a node did not trigger change detection
+
+
+## [0.0.22] - 2023-06-15
+
+## Added
+- clicking on the background of the diagram will deselect all elements
+- multiple IED selection
+- animated connections to see better the direction of messages
+- toggleable animation
+- MMS messages
+- preferences are persisted in local storage
+
+## Changed
+- new diagram design
+- sidebar has separate sections for focus mode and preferences
+
+## [0.0.12] - 2023-04-27
+
+### Fixed
+
+- Rename Labels in Sidebar Panel
+
+## [0.0.11] - 2023-04-26
+
+### Added
+
+- Experiment: hide irrelevant stuff
+- Experiment: search by IED name
+
+## [0.0.10] - 2023-04-26
+
+### Added
+
+- Added Sampled Value Messages to the Communication Explorer
+- Filter by message type
+
+### Fixed
+
+- fixed flickering of the view in case of any change
+
+## [0.0.9] - 2023-04-21
+
+### Fixed
+
+- Missing IED definition crashed the plugin.
+  It ignores the IED connection has a undefined IED.
+
+## [0.0.8] - 2023-04-20
+
+### Added
+
+- IEDs are selectable
+- Selecting an IED will show only relevant IEDs and connections
+- Filter for incoming and outgoing connections
+
+### Fixed
+
+- The SVG no grows with the diagram

--- a/packages/uilib/src/lib/components/diagram/ied-element/ied-element.svelte
+++ b/packages/uilib/src/lib/components/diagram/ied-element/ied-element.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
-import type { IEDElkNode } from '../nodes'
+	import type { IEDElkNode } from "../nodes"
 
-//
-// INPUT
-//
-export let node: IEDElkNode
-export let isSelected = false
-export let disabled = false
-export let testid = ''
+	// 
+	// INPUT
+	// 
+	export let node: IEDElkNode
+	export let isSelected = false
+	export let disabled = false
+	export let testid = ""
+
 </script>
 
 {#if node}
@@ -37,7 +38,6 @@ export let testid = ''
 
 		/* TODO: extract colors */
 		background: var(--color-white);
-		color: var(--color-black);
 		border: 1px solid var(--color-cyan);
 		box-shadow: inset 0px 0px 6px rgba(77, 93, 99, 0.15);
 		border-radius: 5px;

--- a/packages/uilib/src/lib/plugins/communication-explorer/communication-explorer.svelte
+++ b/packages/uilib/src/lib/plugins/communication-explorer/communication-explorer.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-import Theme from '../../theme/theme.svelte'
-import { clearSelection } from './_store-view-filter'
-import TelemetryView from './telemetry-view/telemetry-view.svelte'
+	import Theme from "../../theme/theme.svelte"
+	import { clearSelection } from "./_store-view-filter"
+	import TelemetryView from "./telemetry-view/telemetry-view.svelte"
 
-export let root: Element
+	export let root: Element
 
-$: root && clearSelection()
+	$: root && clearSelection()
 </script>
 
 <Theme>
@@ -22,6 +22,5 @@ $: root && clearSelection()
 		position: relative;
 		font-size: 12px;
 		min-height: 80vh;
-		color-scheme: light;
 	}
 </style>

--- a/packages/uilib/src/lib/plugins/communication-explorer/sidebar/sidebar.svelte
+++ b/packages/uilib/src/lib/plugins/communication-explorer/sidebar/sidebar.svelte
@@ -1,336 +1,345 @@
 <script lang="ts">
-    import {
-    	filterState,
-    	type SelectedFilter,
-    } from "../_store-view-filter/selected-filter-store"
-    import {
-    	selectIEDNode,
-    	clearSelection,
-    	setNameFilter,
-        clearIEDSelection,
-        toggleMultiSelectionOfIED,
-    } from "../_store-view-filter/selected-filter-store-functions"
-    import ConnectionSelector from "./assets/connection-selector.svg"
-    import type { BayNode, IEDNode, RootNode } from "../../../components/diagram"
-    import { ConnectionTypeFilter } from "./connection-type-filter"
-    import { MessageTypeFilter } from "./message-type-filter"
-    import ConnectionInformation from "./connection-information/connection-information.svelte"
-    import IEDAccordion from "./ied-accordion/ied-accordion.svelte"
-    import { preferences$ } from "../_store-preferences"
+import {
+	filterState,
+	type SelectedFilter
+} from '../_store-view-filter/selected-filter-store'
+import {
+	selectIEDNode,
+	clearSelection,
+	setNameFilter,
+	clearIEDSelection,
+	toggleMultiSelectionOfIED
+} from '../_store-view-filter/selected-filter-store-functions'
+import ConnectionSelector from './assets/connection-selector.svg'
+import type { BayNode, IEDNode, RootNode } from '../../../components/diagram'
+import { ConnectionTypeFilter } from './connection-type-filter'
+import { MessageTypeFilter } from './message-type-filter'
+import ConnectionInformation from './connection-information/connection-information.svelte'
+import IEDAccordion from './ied-accordion/ied-accordion.svelte'
+import { preferences$ } from '../_store-preferences'
 
-    export let rootNode: RootNode
-    export let bays: string[]
-    let IEDs = rootNode.children;  
-    let searchQuery = ""
-    let filterTextFieldFocused = false
+export let rootNode: RootNode
+export let bays: string[]
+let IEDs = rootNode.children
+let searchQuery = ''
+let filterTextFieldFocused = false
 
-    $: IEDSelections = $filterState?.selectedIEDs
-    $: ConnectionSelection = $filterState.selectedConnection
-    $: selectedMessageTypes = $filterState.selectedMessageTypes
-    $: isIedFiltersDisabled =
-        $filterState?.selectedConnection !== undefined
-    $: isConnectionDirectionDisabled = handleConnectionDirectionDisabled(
-    	$filterState,
-    	isIedFiltersDisabled
-    )
-    $: filteredIEDs = (searchQuery && IEDs?.filter(ied => ied.label.toLowerCase().includes(searchQuery.toLowerCase()))) || IEDs
-    $: filteredBays = (searchQuery && bays?.filter(bay => bay.toLowerCase().includes(searchQuery.toLowerCase()))) || bays
+$: IEDSelections = $filterState?.selectedIEDs
+$: ConnectionSelection = $filterState.selectedConnection
+$: selectedMessageTypes = $filterState.selectedMessageTypes
+$: isIedFiltersDisabled = $filterState?.selectedConnection !== undefined
+$: isConnectionDirectionDisabled = handleConnectionDirectionDisabled(
+	$filterState,
+	isIedFiltersDisabled
+)
+$: filteredIEDs =
+	(searchQuery &&
+		IEDs?.filter((ied) =>
+			ied.label.toLowerCase().includes(searchQuery.toLowerCase())
+		)) ||
+	IEDs
+$: filteredBays =
+	(searchQuery &&
+		bays?.filter((bay) =>
+			bay.toLowerCase().includes(searchQuery.toLowerCase())
+		)) ||
+	bays
 
-    function handleConnectionDirectionDisabled(
-    	filter: SelectedFilter,
-    	iedFilterDisabled: boolean
-    ): boolean {        
-    	if (iedFilterDisabled) return true
+function handleConnectionDirectionDisabled(
+	filter: SelectedFilter,
+	iedFilterDisabled: boolean
+): boolean {
+	if (iedFilterDisabled) return true
 
-    	const selectedIEDs = filter?.selectedIEDs
-    	const selectedCon = filter?.selectedConnection?.id
+	const selectedIEDs = filter?.selectedIEDs
+	const selectedCon = filter?.selectedConnection?.id
 
-        return Boolean(selectedIEDs.length === 0 && selectedCon === undefined)
-    }
+	return Boolean(selectedIEDs.length === 0 && selectedCon === undefined)
+}
 
-    function handleNameFilterChange(e: Event) {
-    	const target = e.target as HTMLInputElement
-    	setNameFilter(target.value)
-    }
+function handleNameFilterChange(e: Event) {
+	const target = e.target as HTMLInputElement
+	setNameFilter(target.value)
+}
 
-    function handleDropdownSelect(e: Event) {
-        const target = e.target as HTMLElement;
-	    searchQuery = target.innerText|| '';
-        if (bays.includes(searchQuery)) {
-            clearIEDSelection()
-            for (const node of rootNode.children) {
-                if (node.bays && node.bays.has(searchQuery)) {
-                    toggleMultiSelectionOfIED(node)
-                }
-            }
-        }
-        else {
-            let selectedNode = rootNode.children.find(node => node.label == searchQuery)
-            if (selectedNode) {
-                selectIEDNode(selectedNode)
-            }
-        }
-    }
+function handleDropdownSelect(e: Event) {
+	const target = e.target as HTMLElement
+	searchQuery = target.innerText || ''
+	if (bays.includes(searchQuery)) {
+		clearIEDSelection()
+		for (const node of rootNode.children) {
+			if (node.bays?.has(searchQuery)) {
+				toggleMultiSelectionOfIED(node)
+			}
+		}
+	} else {
+		let selectedNode = rootNode.children.find(
+			(node) => node.label == searchQuery
+		)
+		if (selectedNode) {
+			selectIEDNode(selectedNode)
+		}
+	}
+}
 
-    function clearAll() {
-        searchQuery = "";
-        clearSelection();
-    }
-  
+function clearAll() {
+	searchQuery = ''
+	clearSelection()
+}
 </script>
 
 <div class="sidebar sidebar-right">
-    <div class="sidebar-content">
-        <!-- svelte-ignore a11y-missing-attribute -->
-        <div class="actions">
-            <a class="clear-all" on:keypress on:click={clearAll}>
-                Clear all
-            </a>
-        </div>
+	<div class="sidebar-content">
+			<!-- svelte-ignore a11y-missing-attribute -->
+			<div class="actions">
+					<a class="clear-all" on:keypress on:click={clearAll}>
+							Clear all
+					</a>
+			</div>
 
-        <div class="search_filter">
-            <img src={ConnectionSelector} alt="connection selector" />
-            <div class="search_container">
-                <input
-                    type="text"
-                    placeholder="Filter IED or bay"
-                    bind:value={searchQuery}
-                    on:focus={()=> filterTextFieldFocused = true}
-                    on:blur={()=> filterTextFieldFocused = false}
-                />
-                {#if filterTextFieldFocused}
-                    <div class="dropdown">
-                        {#if filteredIEDs.length > 0}
-                            <div class="dropdown_label">
-                                IEDs ({filteredIEDs.length})
-                            </div>
-                            {#each filteredIEDs as ied}
-                                <div class="dropdown_content" role="button" tabindex="0" on:mousedown={handleDropdownSelect}>
-                                    {ied.label}
-                                </div>
-                            {/each}
-                            {#if filteredBays.length > 0}
-                                <hr>
-                            {/if}
-                        {/if}
-                        {#if filteredBays.length > 0}
-                            <div class="dropdown_label">
-                                bays ({filteredBays.length})
-                            </div>
-                            {#each filteredBays as bay}
-                                <div class="dropdown_content" role="button" tabindex="0" on:mousedown={handleDropdownSelect}>
-                                    {bay}
-                                </div>
-                            {/each}
-                        {/if}
-                    </div>  
-                {/if} 
-            </div>
-        </div>
+			<div class="search_filter">
+					<img src={ConnectionSelector} alt="connection selector" />
+					<div class="search_container">
+							<input
+									type="text"
+									placeholder="Filter IED or bay"
+									bind:value={searchQuery}
+									on:focus={()=> filterTextFieldFocused = true}
+									on:blur={()=> filterTextFieldFocused = false}
+							/>
+							{#if filterTextFieldFocused}
+									<div class="dropdown">
+											{#if filteredIEDs.length > 0}
+													<div class="dropdown_label">
+															IEDs ({filteredIEDs.length})
+													</div>
+													{#each filteredIEDs as ied}
+															<div class="dropdown_content" role="button" tabindex="0" on:mousedown={handleDropdownSelect}>
+																	{ied.label}
+															</div>
+													{/each}
+													{#if filteredBays.length > 0}
+															<hr>
+													{/if}
+											{/if}
+											{#if filteredBays.length > 0}
+													<div class="dropdown_label">
+															bays ({filteredBays.length})
+													</div>
+													{#each filteredBays as bay}
+															<div class="dropdown_content" role="button" tabindex="0" on:mousedown={handleDropdownSelect}>
+																	{bay}
+															</div>
+													{/each}
+											{/if}
+									</div>  
+							{/if} 
+					</div>
+			</div>
 
-        <div class="centered">
-            <ConnectionTypeFilter 
-                disabled={isConnectionDirectionDisabled} 
-                isFilterIncomingActive={$filterState.incomingMessageFilterActive}
-                isFilterOutgoingActive={$filterState.outgoingMessageFilterActive}
-            />
-        </div>
+			<div class="centered">
+					<ConnectionTypeFilter 
+							disabled={isConnectionDirectionDisabled} 
+							isFilterIncomingActive={$filterState.incomingMessageFilterActive}
+							isFilterOutgoingActive={$filterState.outgoingMessageFilterActive}
+					/>
+			</div>
 
-        <hr class="dashed-line" />
-        <MessageTypeFilter
-            {selectedMessageTypes}
-            filterDisabled={isIedFiltersDisabled}
-        />
+			<hr class="dashed-line" />
+			<MessageTypeFilter
+					{selectedMessageTypes}
+					filterDisabled={isIedFiltersDisabled}
+			/>
 
-        {#if IEDSelections.length > 0}
-            <hr class="seperation-line" />
-            <ul class="ied-detail-list">
-                {#each IEDSelections as IEDSelection}
-                    <li>
-                        <IEDAccordion {IEDSelection} {rootNode} />
-                    </li>
-                {/each}
-            </ul>
-        {/if}
+			{#if IEDSelections.length > 0}
+					<hr class="seperation-line" />
+					<ul class="ied-detail-list">
+							{#each IEDSelections as IEDSelection}
+									<li>
+											<IEDAccordion {IEDSelection} {rootNode} />
+									</li>
+							{/each}
+					</ul>
+			{/if}
 
-        {#if ConnectionSelection !== undefined}
-            <hr class="seperation-line" />
-            <ConnectionInformation {ConnectionSelection} />
-        {/if}
+			{#if ConnectionSelection !== undefined}
+					<hr class="seperation-line" />
+					<ConnectionInformation {ConnectionSelection} />
+			{/if}
 
-        <hr class="seperation-line" />
+			<hr class="seperation-line" />
 
-        <h2>Focus Mode</h2>
+			<h2>Focus Mode</h2>
 
-        <label class="ied-search">
-            <span class="ied-search-headline">Filter IEDs by name:</span>
-            <input
-                class="input"
-                type="text"
-                placeholder="e.g.: XAT"
-                value={$filterState.nameFilter}
-                on:input={handleNameFilterChange}
-            />
-        </label>
+			<label class="ied-search">
+					<span class="ied-search-headline">Filter IEDs by name:</span>
+					<input
+							class="input"
+							type="text"
+							placeholder="e.g.: XAT"
+							value={$filterState.nameFilter}
+							on:input={handleNameFilterChange}
+					/>
+			</label>
 
-        <div class="checkbox-group">
-            <label>
-                <input
-                    type="checkbox"
-                    bind:checked={$preferences$.isFocusModeOn}
-                />
-                <span>Focus on selected IEDs</span>
-            </label>
-        </div>
+			<div class="checkbox-group">
+					<label>
+							<input
+									type="checkbox"
+									bind:checked={$preferences$.isFocusModeOn}
+							/>
+							<span>Focus on selected IEDs</span>
+					</label>
+			</div>
 
-        <h2>Preferences</h2>
+			<h2>Preferences</h2>
 
-        <div class="arrows-visible">
-            <label>
-                <input
-                    type="checkbox"
-                    bind:checked={$preferences$.showConnectionArrows}
-                />
-                <span>Show arrows on connections</span>
-            </label>
-        </div>
+			<div class="arrows-visible">
+					<label>
+							<input
+									type="checkbox"
+									bind:checked={$preferences$.showConnectionArrows}
+							/>
+							<span>Show arrows on connections</span>
+					</label>
+			</div>
 
-        <div class="checkbox-group">
-            <label>
-                <input
-                    type="checkbox"
-                    bind:checked={$preferences$.playConnectionAnimation}
-                />
-                <span>Play data flow animation</span>
-            </label>
-        </div>
-    </div>
+			<div class="checkbox-group">
+					<label>
+							<input
+									type="checkbox"
+									bind:checked={$preferences$.playConnectionAnimation}
+							/>
+							<span>Play data flow animation</span>
+					</label>
+			</div>
+	</div>
 </div>
 
 <style>
-    hr {
-        margin: 2rem 0;
-    }
+	hr {
+			margin: 2rem 0;
+	}
 
-    .sidebar {
-        height: 100%;
-        width: var(--sidebar-width);
-        overflow: hidden;
-    }
+	.sidebar {
+			height: 100%;
+			width: var(--sidebar-width);
+			overflow: hidden;
+	}
 
-    .sidebar .sidebar-content {
-        padding: 1rem;
-        background-color: var(--mdc-theme-background);
-        height: calc(100% - 2rem);
-        overflow: auto;
-        min-width: 330px;
-				color: var(--mdc-theme-on-background);
-    }
+	.sidebar .sidebar-content {
+			padding: 1rem;
+			background-color: var(--mdc-theme-background);
+			height: calc(100% - 2rem);
+			overflow: auto;
+			min-width: 330px;
+			color: var(--mdc-theme-on-background);
+	}
 
-    .search_filter {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        margin-bottom: 2rem;
-    }
+	.search_filter {
+			display: flex;
+			align-items: center;
+			gap: 1rem;
+			margin-bottom: 2rem;
+	}
 
-    .search_filter img {
-        height: 1.3rem;
-        width: 1.3rem;
-    }
+	.search_filter img {
+			height: 1.3rem;
+			width: 1.3rem;
+	}
 
-    .search_container {
-        position: relative;
-        width: 100%;
-    }
+	.search_container {
+			position: relative;
+			width: 100%;
+	}
 
-    .search_container input {
-        padding: 14px 20px 12px 15px;
-        border: none;
-        border-bottom: 1px solid #ddd;
-        width: 100%;
-        box-sizing: border-box;
-    }
-    
-    .dropdown {
-        position: absolute;
-        width: 100%;
-    	background-color: #f6f6f6;
-        border: 1px solid #ddd;
-        z-index: 1;
-    }
+	.search_container input {
+			padding: 14px 20px 12px 15px;
+			border: none;
+			border-bottom: 1px solid #ddd;
+			width: 100%;
+			box-sizing: border-box;
+	}
+	
+	.dropdown {
+			position: absolute;
+			width: 100%;
+		background-color: #f6f6f6;
+			border: 1px solid #ddd;
+			z-index: 1;
+	}
 
-    .dropdown_label {
-    	color: gray;
-    	padding: 8px;
-    	font-size: 1em;
-        box-sizing: border-box;
-    }
+	.dropdown_label {
+		color: gray;
+		padding: 8px;
+		font-size: 1em;
+			box-sizing: border-box;
+	}
 
-    .dropdown_content {
-    	color: black;
-        padding: 4px 16px;
-        text-decoration: none;
-        box-sizing: border-box;
-    }
-    .dropdown_content:hover {
-     	background-color: #ddd;
-    }
+	.dropdown_content {
+		color: black;
+			padding: 4px 16px;
+			text-decoration: none;
+			box-sizing: border-box;
+	}
+	.dropdown_content:hover {
+		 background-color: #ddd;
+	}
 
-    .dropdown hr {
-    	border: none;
-    	background-color: gray;
-    	height: 1px;
-        margin: 0.5em;
-        box-sizing: border-box;
-    }
-    
-    .actions {
-        display: flex;
-        flex-direction: row-reverse;
-        margin-bottom: 1rem;
-    }
+	.dropdown hr {
+		border: none;
+		background-color: gray;
+		height: 1px;
+			margin: 0.5em;
+			box-sizing: border-box;
+	}
+	
+	.actions {
+			display: flex;
+			flex-direction: row-reverse;
+			margin-bottom: 1rem;
+	}
 
-    .actions .clear-all {
-        cursor: pointer;
-        border: 1px solid rgba(0, 0, 0, 0);
-        border-radius: 5px;
-        padding: 6px 8px;
-        transition: border-color 200ms ease-in-out;
-    }
+	.actions .clear-all {
+			cursor: pointer;
+			border: 1px solid rgba(0, 0, 0, 0);
+			border-radius: 5px;
+			padding: 6px 8px;
+			transition: border-color 200ms ease-in-out;
+	}
 
-    .actions .clear-all:hover {
-        border-color: var(--color-text-disabled-1);
-    }
+	.actions .clear-all:hover {
+			border-color: var(--color-text-disabled-1);
+	}
 
-    .centered {
-        display: flex;
-        justify-content: flex-start;
-    }
+	.centered {
+			display: flex;
+			justify-content: flex-start;
+	}
 
-    .ied-detail-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 2rem;
-    }
-    .ied-search {
-        display: inline-grid;
-    }
+	.ied-detail-list {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+			display: flex;
+			flex-direction: column;
+			gap: 2rem;
+	}
+	.ied-search {
+			display: inline-grid;
+	}
 
-    .ied-search-headline {
-        margin-bottom: 0.5rem;
-    }
-    .input {
-        margin-bottom: 1rem;
-    }
-    .dashed-line {
-        border: 0.1rem dashed var(--color-cyan-30-pc-opacity);
-    }
-    .seperation-line {
-        border: none;
-        border-top: 0.1rem solid var(--color-accent);
-    }
+	.ied-search-headline {
+			margin-bottom: 0.5rem;
+	}
+	.input {
+			margin-bottom: 1rem;
+	}
+	.dashed-line {
+			border: 0.1rem dashed var(--color-cyan-30-pc-opacity);
+	}
+	.seperation-line {
+			border: none;
+			border-top: 0.1rem solid var(--color-accent);
+	}
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,6 @@ importers:
       lucide-svelte:
         specifier: ^0.474.0
         version: 0.474.0(svelte@5.20.1)
-      mode-watcher:
-        specifier: ^0.5.0
-        version: 0.5.1(svelte@5.20.1)
       paneforge:
         specifier: 1.0.0-next.1
         version: 1.0.0-next.1(svelte@5.20.1)
@@ -5247,11 +5244,6 @@ packages:
 
   mlly@1.7.3:
     resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
-
-  mode-watcher@0.5.1:
-    resolution: {integrity: sha512-adEC6T7TMX/kzQlaO/MtiQOSFekZfQu4MC+lXyoceQG+U5sKpJWZ4yKXqw846ExIuWJgedkOIPqAYYRk/xHm+w==}
-    peerDependencies:
-      svelte: ^4.0.0 || ^5.0.0-next.1
 
   modern-node-polyfills@0.1.0:
     resolution: {integrity: sha512-/Z9mlC56KBxjLZvdNSLqSEFw9jSav43dsUxhLYLN3bZgcSX5VFdixat+QGjb/4NxaGCwW09ABJhZA5oHFj4W4A==}
@@ -13259,10 +13251,6 @@ snapshots:
       pathe: 1.1.2
       pkg-types: 1.2.1
       ufo: 1.5.4
-
-  mode-watcher@0.5.1(svelte@5.20.1):
-    dependencies:
-      svelte: 5.20.1
 
   modern-node-polyfills@0.1.0:
     dependencies:


### PR DESCRIPTION
# 🗒 Description

When loading the type-designer plugin, there was a dark theme issue for some plugin (communication explorer and auto-doc for example).
The issue came from the  ui-svelte package and the sonner component. It was imported the mode-watcher (an utility to watch the css `prefers-color-scheme`class), which automatically added the class to the document (which is not used otherwise by the instance for now), based on system preference : often dark mode.

This dependency was removed.

## 🔦 Related

Closes #299 
