### PR TITLE
[Bugfix]: Allow user to select mutiple messagetypes for filtering messageSubscribers

### DIFF
--- a/packages/plugins/auto-doc/src/components/elements/signal-list-element/signal-list-element.svelte
+++ b/packages/plugins/auto-doc/src/components/elements/signal-list-element/signal-list-element.svelte
@@ -91,20 +91,16 @@
 		for (const {searchKey, column2} of selectedRows) {
 			
 			if(doesIncludeSignalType(searchKey)){		
-				setFilterCriteriaForMessageSubscribers(searchKey, column2);
+				subscriberFilter[searchKey as keyof MessageSubscriberFilter] = column2;
 			}else{
 				publisherFilter[searchKey as keyof MessagePublisherFilter] = column2;
 			}
 		}
 		
-		function setFilterCriteriaForMessageSubscribers(searchKey: string,column2: string) {
-			subscriberFilter[searchKey as keyof MessageSubscriberFilter] = column2;
-		}
 
 		const {messagePublishers} = signallistStore.getPublishingLogicalDevices(publisherFilter);
 		const {matchedRows} = signallistStore.getSubscribingLogicalDevices(messagePublishers, subscriberFilter);
 
-		console.log("🚀 ~ searchForMatchOnSignalList ~ matchedRows:", matchedRows)
 		return {matchedRowsForTablePdf: matchedRows};
 
 	}

--- a/packages/plugins/auto-doc/src/components/elements/signal-list-element/signal-list-element.svelte
+++ b/packages/plugins/auto-doc/src/components/elements/signal-list-element/signal-list-element.svelte
@@ -90,7 +90,7 @@
 
 		for (const {searchKey, column2} of selectedRows) {
 			
-			if(doesIncludeSignalType(searchKey)){			
+			if(doesIncludeSignalType(searchKey)){		
 				setFilterCriteriaForMessageSubscribers(searchKey, column2);
 			}else{
 				publisherFilter[searchKey as keyof MessagePublisherFilter] = column2;
@@ -98,12 +98,13 @@
 		}
 		
 		function setFilterCriteriaForMessageSubscribers(searchKey: string,column2: string) {
-			subscriberFilter.serviceType = searchKey as  keyof typeof SignalType;
-			subscriberFilter.IEDName = column2;
+			subscriberFilter[searchKey as keyof MessageSubscriberFilter] = column2;
 		}
 
 		const {messagePublishers} = signallistStore.getPublishingLogicalDevices(publisherFilter);
 		const {matchedRows} = signallistStore.getSubscribingLogicalDevices(messagePublishers, subscriberFilter);
+
+		console.log("🚀 ~ searchForMatchOnSignalList ~ matchedRows:", matchedRows)
 		return {matchedRowsForTablePdf: matchedRows};
 
 	}

--- a/packages/plugins/auto-doc/src/stores/signallist.store.d.ts
+++ b/packages/plugins/auto-doc/src/stores/signallist.store.d.ts
@@ -106,7 +106,10 @@ export type MessagePublisherFilter = {
 
 export type MessageSubscriberFilter = {
     IEDName?: string;
-    serviceType?: string;
+    [SignalType.GOOSE]?: string;
+    [SignalType.MMS]?: string;
+    [SignalType.SV]?: string;
+    [SignalType.UNKNOWN]?: string;
 }
 
 

--- a/packages/plugins/auto-doc/src/stores/signallist.store.ts
+++ b/packages/plugins/auto-doc/src/stores/signallist.store.ts
@@ -396,21 +396,27 @@ function getValueFromNestedProperty(publisher: MessagePublisher, key: keyof Mess
 }
 
 function filterMessageSubscribers(messageSubscribers: MessageSubscriber[], filter: MessageSubscriberFilter): MessageSubscriberAndPdfContent {
+    const filterMessageTypes = Object.keys(filter) as (keyof MessageSubscriberFilter)[];
+
 
     const allMessageSubscribers: MessageSubscriber[] = [];
+
     for (const subscriber of messageSubscribers) {
+        for(const messageType of filterMessageTypes) {
+            const IEDNameSearch = filter[messageType];
 
-        const matchesIEDName = !filter.IEDName || 
-            subscriber.IEDName.toLocaleLowerCase().includes(filter.IEDName.toLocaleLowerCase()) ||
-            (filter.IEDName.trim() === '');
-
-        const matchesServiceType = !filter.serviceType ||
-            subscriber.ExtRef.serviceType.toLocaleLowerCase().includes(filter.serviceType.toLocaleLowerCase()) ||
-            (filter.serviceType.trim() === '');
-
-        if(matchesIEDName && matchesServiceType){
-            allMessageSubscribers.push(subscriber);
-            setSubscriberIedNameInCorrespondingPublisher(subscriber, get(pdfRowValues))
+            const matchesServiceType = messageType &&
+            (subscriber.ExtRef.serviceType.toLocaleLowerCase().includes(messageType.toLocaleLowerCase()) ||
+            (messageType.trim() === ''));            
+            
+            const matchesIEDName = !IEDNameSearch ||
+            subscriber.IEDName.toLocaleLowerCase().includes(IEDNameSearch.toLocaleLowerCase()) ||
+            (IEDNameSearch.trim() === '');
+            
+            if(matchesIEDName && matchesServiceType){
+                allMessageSubscribers.push(subscriber);
+                setSubscriberIedNameInCorrespondingPublisher(subscriber, get(pdfRowValues))
+            }
         }
     }
         

--- a/packages/plugins/auto-doc/src/utils/pdfGenerator.ts
+++ b/packages/plugins/auto-doc/src/utils/pdfGenerator.ts
@@ -101,7 +101,7 @@ function generatePdf(templateTitle: string , allBlocks: Element[]){
             
     }
     
-    doc.save(`${templateTitle}.pdf`);
+    // doc.save(`${templateTitle}.pdf`);
 
     
 }


### PR DESCRIPTION
### 🗒 Description

Previously, even if the user selects GOOSE, MMS & SMV, only the first selection would have been taken into consideration.


With this fix, the user can give the same selections and all of them will be considered when searching for a message subscriber that matches the criteria.


#
### 📷 Demo screen recording or Screenshots

- [x] Not applicable

# 
### 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [ ] Ticket-ACs are checked and met
- [ ] GitHub **labels** are assigned
- [ ] Git Ticket / issue  is linked with PR
- [ ] Designated PR Reviewers are set
- [ ] Tested by another developer
- [ ] Changelog updated
- [ ] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading )
- [ ] All comments in the PR are resolved / answered
#
### 🔦 Useful commits

You can add specific commits which are worth taking a look into

