### PR TITLE
Fix: Direct doc access

### DIFF
--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2025-03-14
+
+### Changed
+
+- Migrate event store to V3
+
+### Fixed
+
+- Remove direct doc access
+
 ## [1.9.0] - 2025-03-14
 
 ### Added

--- a/packages/plugins/auto-doc/package.json
+++ b/packages/plugins/auto-doc/package.json
@@ -36,6 +36,8 @@
 		"zipcelx": "^1.6.2"
 	},
 	"devDependencies": {
+		"@oscd-plugins/core-api": "workspace:^",
+		"@oscd-plugins/core-ui-svelte": "workspace:^",
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/vite-plugin-svelte": "^3.1.1",
 		"@tsconfig/svelte": "^5.0.4",

--- a/packages/plugins/auto-doc/package.json
+++ b/packages/plugins/auto-doc/package.json
@@ -37,7 +37,6 @@
 	},
 	"devDependencies": {
 		"@oscd-plugins/core-api": "workspace:^",
-		"@oscd-plugins/core-ui-svelte": "workspace:^",
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/vite-plugin-svelte": "^3.1.1",
 		"@tsconfig/svelte": "^5.0.4",

--- a/packages/plugins/auto-doc/src/components/template-builder/template-builder.svelte
+++ b/packages/plugins/auto-doc/src/components/template-builder/template-builder.svelte
@@ -47,7 +47,7 @@
 
 
     function addElement(type: ElementType){
-        docTemplatesStore.addBlockToDocumentTemplate(template, type, blockElements.length)
+        docTemplatesStore.addBlockToDocumentTemplate(template, type)
     }
 
 
@@ -79,7 +79,7 @@
         const calculatedPosition = index + direction;
         const referenceBlock = blockElements[calculatedPosition];
         const reference = template.querySelector(`Block[id="${referenceBlock?.id}"]`);
-        docTemplatesStore.moveBlockInDocumentTemplate(template, elementId, calculatedPosition, reference);
+        docTemplatesStore.moveBlockInDocumentTemplate(template, elementId, reference);
     }
 
     function deleteBlockElement(event: CustomEvent<{elementId: string}>){

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.spec.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.spec.ts
@@ -39,8 +39,8 @@ describe('DocumentTemplateStore', () => {
 						}
 					),
 					moveAndDispatchActionEvent: vi.fn().mockImplementation(
-						(_: Element, newDocTemplate: Element, blockElement: Element, reference?: Node | null) => {
-							insertBlock(newDocTemplate, blockElement, reference);
+						(docTemplate: Element, blockElement: Element, reference?: Node | null) => {
+							insertBlock(docTemplate, blockElement, reference);
 						}
 					),
 					deleteAndDispatchActionEvent: vi.fn().mockImplementation(

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.spec.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.spec.ts
@@ -1,12 +1,12 @@
 import { docTemplatesStore } from './doc-templates.store';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { get, writable, type Writable } from 'svelte/store';
 import { pluginStore } from './index';
 
 describe('DocumentTemplateStore', () => {
-  let xmlDocument: Writable<XMLDocument | undefined>;;
+  	let xmlDocument: Writable<XMLDocument | undefined>;;
 
-  beforeEach(() => {
+  	beforeEach(() => {
 		xmlDocument = writable<XMLDocument | undefined>(undefined);
 		const parser = new DOMParser();
 		const xmlString = "<SCL></SCL>";
@@ -18,9 +18,54 @@ describe('DocumentTemplateStore', () => {
 		});
 
 		docTemplatesStore.init();
-  });
+	});
 
-  it('should create a "private" element with type="AUTO_DOC" if it does not exist', () => {
+	function mockEventStore() {
+		vi.mock(import("./events.store.js"), async (importOriginal) => {
+			const insertBlock = (parent: Element, element: Element, reference?: Node | null) => {
+				parent.appendChild(element);
+				if(reference) {
+					parent.insertBefore(element, reference);
+				}
+			}
+						
+			const mod = await importOriginal();
+			return {
+				eventStore: {
+					...mod.eventStore, 
+					createAndDispatchActionEvent: vi.fn().mockImplementation(
+						(docTemplate: Element, blockElement: Element, reference?: Node | null) => {
+							insertBlock(docTemplate, blockElement, reference);
+						}
+					),
+					moveAndDispatchActionEvent: vi.fn().mockImplementation(
+						(_: Element, newDocTemplate: Element, blockElement: Element, reference?: Node | null) => {
+							insertBlock(newDocTemplate, blockElement, reference);
+						}
+					),
+					deleteAndDispatchActionEvent: vi.fn().mockImplementation(
+						(docTemplate: Element, blockElement: Element) => {
+							docTemplate.removeChild(blockElement);
+						}
+					),
+					updateAndDispatchActionEvent: vi.fn().mockImplementation(
+						(docTemplate: Element, updates: Record<string, string | null>) => {
+							const { title, description } = updates;
+							if(title) {
+								docTemplate.setAttribute("title", title);
+							}
+
+							if(description) {
+								docTemplate.setAttribute("description", description);
+							}
+						}
+					),
+				}	
+			};
+		});
+	}
+
+	it('should create a "private" element with type="AUTO_DOC" if it does not exist', () => {
     	// Act
 		const autoDocArea = docTemplatesStore.privateArea;
 
@@ -31,9 +76,9 @@ describe('DocumentTemplateStore', () => {
 			expect(value?.getAttribute('type')).toBe('AUTO_DOC');
 		})();
 
-  });
+	});
 
-  it('should not create a new "private" element if one already exists', () => {
+	it('should not create a new "private" element if one already exists', () => {
 		// Act
 		docTemplatesStore.init();
 		const autoDocArea = docTemplatesStore.privateArea;
@@ -43,7 +88,7 @@ describe('DocumentTemplateStore', () => {
 				const xmlDocValue = get(xmlDocument);
 		expect(xmlDocValue?.documentElement.querySelectorAll('Private[type="AUTO_DOC"]').length).toBe(1);
 		})();
-  });
+	});
 
 	it('should add a new "DocumentTemplate" element with current date, description, and id attributes', () => {
 		// Arrange
@@ -118,7 +163,7 @@ describe('DocumentTemplateStore', () => {
 		const type = "text";
 
 		// Act
-		const blockId = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 0);
+		const blockId = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
 
 		// Assert
 		const blockElements = getAllBlockElements(docDef);
@@ -140,7 +185,7 @@ describe('DocumentTemplateStore', () => {
 			throw new Error('DocumentTemplate not found');
 		}
 		const type = "text";
-		const blockId = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 0);
+		const blockId = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
 
 		// Act
 		const retrievedBlock = docTemplatesStore.getBlockOfDocumentTemplate(generatedId, blockId);
@@ -164,9 +209,9 @@ describe('DocumentTemplateStore', () => {
 		const type = "image";
 
 		// Add blocks to the document definition
-		docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 0);
-		docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 1);
-		docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 2);
+		docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
 
 		// Act
 		const blocks = docTemplatesStore.getAllBlocksOfDocumentTemplate(generatedId);
@@ -189,12 +234,13 @@ describe('DocumentTemplateStore', () => {
 		const type = "text";
 
 		// Act
-		const idBlock1 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 0);
-		const idBlock2 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 1);
-		const idBlock3 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 1);
+		let blockElements = docDef?.querySelectorAll('Block');
+		const idBlock1 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		const idBlock2 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		const idBlock3 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, docDef.children[1]);
 
 		// Assert
-		const blockElements = docDef?.querySelectorAll('Block');
+		blockElements = docDef?.querySelectorAll('Block');
 		if(!blockElements) {
 			throw new Error('Block elements not found');
 		}
@@ -220,9 +266,9 @@ describe('DocumentTemplateStore', () => {
 		const type = "signalList";
 
 		// Add blocks to the document definition
-		const idBlock1 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 0);
-		const idBlock2 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 1);
-		const idBlock3 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 2);
+		const idBlock1 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		const idBlock2 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		const idBlock3 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
 
 		// Assert
 		let blockElements = getAllBlockElements(docDef);
@@ -232,7 +278,8 @@ describe('DocumentTemplateStore', () => {
 		expect(idBlock3).toBe(blockElements?.[2]?.getAttribute('id'));
 
 		// Act
-		docTemplatesStore.moveBlockInDocumentTemplate(docDef, idBlock3, 0);
+		const block1Reference = docDef.querySelector(`Block[id="${idBlock1}"]`);
+		docTemplatesStore.moveBlockInDocumentTemplate(docDef, idBlock3, block1Reference);
 
 		// Assert
 		blockElements = getAllBlockElements(docDef);
@@ -241,6 +288,8 @@ describe('DocumentTemplateStore', () => {
 		expect(idBlock1).toBe(blockElements?.[1]?.getAttribute('id'));
 		expect(idBlock2).toBe(blockElements?.[2]?.getAttribute('id'));
 	});
+
+	
 	
 	it('should duplicate a block from the document definition', () => {
 		// Arrange
@@ -256,9 +305,9 @@ describe('DocumentTemplateStore', () => {
 		const type = "text";
 
 		// Add blocks to the document definition
-		const idBlock1 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 0);
-		const idBlock2 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 1);
-		const idBlock3 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 2);
+		const idBlock1 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		const idBlock2 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		const idBlock3 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
 
 		// Act
 		docTemplatesStore.duplicateBlockFromDocumentTemplate(docDef, idBlock2, 2);
@@ -294,9 +343,9 @@ describe('DocumentTemplateStore', () => {
 		const type = "text";
 
 		// Add blocks to the document definition
-		const idBlock1 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 0);
-		const idBlock2 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 1);
-		const idBlock3 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 2);
+		const idBlock1 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		const idBlock2 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
+		const idBlock3 = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
 
 		// Act
 		docTemplatesStore.deleteBlockFromDocumentTemplate(docDef, idBlock2);
@@ -386,7 +435,7 @@ describe('DocumentTemplateStore', () => {
 		}
 		const updatedContent = 'Updated block content';
 		const type = "signalList";
-		const blockId = docTemplatesStore.addBlockToDocumentTemplate(docDef, type, 0);
+		const blockId = docTemplatesStore.addBlockToDocumentTemplate(docDef, type);
 	
 		// Act
 		docTemplatesStore.editBlockContentOfDocumentTemplate(docDef, blockId, updatedContent);

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.spec.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.spec.ts
@@ -44,8 +44,23 @@ describe('DocumentTemplateStore', () => {
 						}
 					),
 					deleteAndDispatchActionEvent: vi.fn().mockImplementation(
-						(docTemplate: Element, blockElement: Element) => {
-							docTemplate.removeChild(blockElement);
+						(blockElement: Element) => {
+    						const privateArea = get(docTemplatesStore.privateArea);
+							if(!privateArea) {
+								return;
+							}
+							
+							const docDef = privateArea.querySelector('DocumentTemplate');
+							if(!docDef) {
+								throw new Error("DocumentTemplate not found");
+							}
+							
+							const isDocTemplate = privateArea.querySelector(`DocumentTemplate[id="${blockElement.id}"]`);
+							if(isDocTemplate) {
+								privateArea.removeChild(blockElement);
+							} else {
+								docDef.removeChild(blockElement);
+							}
 						}
 					),
 					updateAndDispatchActionEvent: vi.fn().mockImplementation(

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
@@ -33,18 +33,8 @@ function createAutoDocArea(xmlDocument: Document): Element {
     }
 
     const newPrivateArea = createElement(xmlDocument, 'Private', { type: 'AUTO_DOC' });
-    rootElement.appendChild(newPrivateArea);
-
     eventStore.createAndDispatchActionEvent(rootElement, newPrivateArea);
     return newPrivateArea;
-}
-
-function insertBlockAtPosition(docDef: Element, blockIdElement: Element, position: number) {
-    if (position >= 0 && position < docDef.children.length) {
-        docDef.insertBefore(blockIdElement, docDef.children[position]);
-    } else {
-        docDef.appendChild(blockIdElement);
-    }
 }
 
 //==== PUBLIC ACTIONS
@@ -95,7 +85,7 @@ function addDocumentTemplate(): string | null {
             id: id,
             date: new Date().toISOString()
         });
-        currentPrivateArea.appendChild(newDocDef);
+
         eventStore.createAndDispatchActionEvent(currentPrivateArea, newDocDef);
         generatedId = id;
     }
@@ -108,11 +98,9 @@ function editDocumentTemplateTitleAndDescription(docTemplateId: string, newTitle
     if (docTemplate) {
         const updates: { title?: string; description?: string, id?: string; date?: string } = {};
         if (newTitle) {
-            docTemplate.setAttribute('title', newTitle);
             updates.title = newTitle;
         }
         if (newDescription) {
-            docTemplate.setAttribute('description', newDescription);
             updates.description = newDescription;
         }
         const id = docTemplate.getAttribute('id');
@@ -129,7 +117,7 @@ function editDocumentTemplateTitleAndDescription(docTemplateId: string, newTitle
     }
 }
 
-function addBlockToDocumentTemplate(docTemplate: Element, type: ElementType, position: number) {
+function addBlockToDocumentTemplate(docTemplate: Element, type: ElementType, reference?: Element | null) {
     const generatedId = uuidv4();
     const xmlDoc = get(xmlDocument);
     if (!xmlDoc) {
@@ -139,11 +127,8 @@ function addBlockToDocumentTemplate(docTemplate: Element, type: ElementType, pos
         id: generatedId,
         type: type 
     });
-    docTemplate.appendChild(blockElement);
 
-    insertBlockAtPosition(docTemplate, blockElement, position);
-    eventStore.createAndDispatchActionEvent(docTemplate, blockElement);
-    eventStore.moveAndDispatchActionEvent(docTemplate, docTemplate, blockElement);
+    eventStore.createAndDispatchActionEvent(docTemplate, blockElement, reference);
 
     return generatedId;
 }
@@ -160,10 +145,9 @@ function editBlockContentOfDocumentTemplate(docTemplate: Element, blockId: strin
     }
 }
 
-function moveBlockInDocumentTemplate(docTemplate: Element, blockId: string, position: number, reference?: Element | null) {
+function moveBlockInDocumentTemplate(docTemplate: Element, blockId: string, reference?: Element | null) {
     const blockIdElement = docTemplate.querySelector(`Block[id="${blockId}"]`);
     if (blockIdElement) {
-        insertBlockAtPosition(docTemplate, blockIdElement, position);
         eventStore.moveAndDispatchActionEvent(docTemplate, docTemplate, blockIdElement, reference);
     }
 }
@@ -171,7 +155,6 @@ function moveBlockInDocumentTemplate(docTemplate: Element, blockId: string, posi
 function deleteBlockFromDocumentTemplate(docTemplate: Element, blockId: string) {
     const blockElement = docTemplate.querySelector(`Block[id="${blockId}"]`);
     if (blockElement && blockElement.parentNode === docTemplate) {
-        docTemplate.removeChild(blockElement);
         eventStore.deleteAndDispatchActionEvent(docTemplate, blockElement);
     }
 }
@@ -181,7 +164,6 @@ function deleteDocumentTemplate(docTemplateId: string) {
     if (currentPrivateArea) {
         const docTemplate = getDocumentTemplate(docTemplateId);
         if (docTemplate) {
-            currentPrivateArea.removeChild(docTemplate);
             eventStore.deleteAndDispatchActionEvent(currentPrivateArea, docTemplate);
         }
     }
@@ -196,8 +178,13 @@ function duplicateBlockFromDocumentTemplate(docTemplate: Element, blockId: strin
     const duplicatedElement = blockElement.cloneNode(true) as Element;
     duplicatedElement.setAttribute("id", uuidv4());
 
-    insertBlockAtPosition(docTemplate, duplicatedElement, position);
-    eventStore.createAndDispatchActionEvent(docTemplate, duplicatedElement, duplicatedElement);
+    let reference: Element | null = null;
+    if(position > 0) {
+        const blocks = docTemplate.querySelectorAll("Block");
+        reference = blocks[position];
+    }
+
+    eventStore.createAndDispatchActionEvent(docTemplate, duplicatedElement, reference);
     
     return duplicatedElement;
 }
@@ -226,7 +213,6 @@ function duplicateDocumentTemplate(docTemplateId: string) {
                 block.setAttribute('id', uuidv4());
             }
 
-            currentPrivateArea.appendChild(newDocTemplate);
             eventStore.createAndDispatchActionEvent(currentPrivateArea, newDocTemplate);
         }
     }

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
@@ -155,7 +155,7 @@ function moveBlockInDocumentTemplate(docTemplate: Element, blockId: string, refe
 function deleteBlockFromDocumentTemplate(docTemplate: Element, blockId: string) {
     const blockElement = docTemplate.querySelector(`Block[id="${blockId}"]`);
     if (blockElement && blockElement.parentNode === docTemplate) {
-        eventStore.deleteAndDispatchActionEvent(docTemplate, blockElement);
+        eventStore.deleteAndDispatchActionEvent(blockElement);
     }
 }
 
@@ -164,7 +164,7 @@ function deleteDocumentTemplate(docTemplateId: string) {
     if (currentPrivateArea) {
         const docTemplate = getDocumentTemplate(docTemplateId);
         if (docTemplate) {
-            eventStore.deleteAndDispatchActionEvent(currentPrivateArea, docTemplate);
+            eventStore.deleteAndDispatchActionEvent(docTemplate);
         }
     }
 }

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
@@ -148,7 +148,7 @@ function editBlockContentOfDocumentTemplate(docTemplate: Element, blockId: strin
 function moveBlockInDocumentTemplate(docTemplate: Element, blockId: string, reference?: Element | null) {
     const blockIdElement = docTemplate.querySelector(`Block[id="${blockId}"]`);
     if (blockIdElement) {
-        eventStore.moveAndDispatchActionEvent(docTemplate, docTemplate, blockIdElement, reference);
+        eventStore.moveAndDispatchActionEvent(docTemplate, blockIdElement, reference);
     }
 }
 

--- a/packages/plugins/auto-doc/src/stores/events.store.ts
+++ b/packages/plugins/auto-doc/src/stores/events.store.ts
@@ -40,11 +40,12 @@ function moveAndDispatchActionEvent(oldParent: Element, newParent: Element, elem
 	if(reference === undefined) {
 		reference = null;
 	}
-	
+
 	const event = newActionEvent({
 		old: {
 			parent: oldParent,
 			element,
+			reference
 		},
 		new: {
 			parent: newParent,

--- a/packages/plugins/auto-doc/src/stores/events.store.ts
+++ b/packages/plugins/auto-doc/src/stores/events.store.ts
@@ -1,9 +1,9 @@
 // SVELTE
 import { get } from 'svelte/store'
 // OPENSCD
+import { createAndDispatchEditEvent } from '@oscd-plugins/core-api/plugin/v1';
 // STORES
 import { pluginStore } from './index'
-import { createAndDispatchEditEvent } from '@oscd-plugins/core-api/plugin/v1';
 
 //====== STORES ======//
 const { pluginHostElement } = pluginStore

--- a/packages/plugins/auto-doc/src/stores/events.store.ts
+++ b/packages/plugins/auto-doc/src/stores/events.store.ts
@@ -22,7 +22,7 @@ function createAndDispatchActionEvent(parent: Element, element: Element, referen
 	});
 }
 
-function deleteAndDispatchActionEvent(_: Element, element: Element) {
+function deleteAndDispatchActionEvent(element: Element) {
 	createAndDispatchEditEvent({
 		host: get(pluginHostElement), 
 		edit: {

--- a/packages/plugins/auto-doc/src/stores/events.store.ts
+++ b/packages/plugins/auto-doc/src/stores/events.store.ts
@@ -1,9 +1,9 @@
 // SVELTE
 import { get } from 'svelte/store'
 // OPENSCD
-import { newActionEvent, createUpdateAction } from '@oscd-plugins/core'
 // STORES
 import { pluginStore } from './index'
+import { createAndDispatchEditEvent } from '@oscd-plugins/core-api/plugin/v1';
 
 //====== STORES ======//
 const { pluginHostElement } = pluginStore
@@ -14,53 +14,49 @@ function createAndDispatchActionEvent(parent: Element, element: Element, referen
 		reference = null;
 	}
 
-	const event = newActionEvent({
-		new: {
-			parent,
-			element,
-			reference,
+	createAndDispatchEditEvent({
+		host: get(pluginHostElement),
+		edit: {
+			parent: parent, 
+			node: element,
+			reference: reference
 		}
-	})
-
-	get(pluginHostElement).dispatchEvent(event)
+	});
 }
 
-function deleteAndDispatchActionEvent(parent: Element, element: Element) {
-	const event = newActionEvent({
-		old: {
-			parent,
-			element
-		}
+function deleteAndDispatchActionEvent(_: Element, element: Element) {
+	createAndDispatchEditEvent({
+		host: get(pluginHostElement), 
+		edit: {
+			node: element
+		}	
 	})
-
-	get(pluginHostElement).dispatchEvent(event)
 }
 
-function moveAndDispatchActionEvent(oldParent: Element, newParent: Element, element: Element, reference?: Node | null) {
+function moveAndDispatchActionEvent(parent: Element, element: Element, reference?: Node | null) {
 	if(reference === undefined) {
 		reference = null;
 	}
 
-	const event = newActionEvent({
-		old: {
-			parent: oldParent,
-			element,
-			reference
-		},
-		new: {
-			parent: newParent,
-			reference 
+	createAndDispatchEditEvent({
+		host: get(pluginHostElement),
+		edit: {
+			parent: parent,
+			node: element,
+			reference: reference
 		}
-	})
-
-	get(pluginHostElement).dispatchEvent(event)
+	});
 }
 
 function updateAndDispatchActionEvent(element: Element, newAttributes: Record<string, string | null>) {
-	const updateAction = createUpdateAction(element, newAttributes)
-	const event = newActionEvent(updateAction)
-
-	get(pluginHostElement).dispatchEvent(event)
+	createAndDispatchEditEvent({
+		host: get(pluginHostElement),
+		edit: {
+			element: element,
+			attributes: newAttributes,
+			attributesNS: {}
+		}
+	});
 }
 
 export const eventStore = {

--- a/packages/plugins/auto-doc/src/stores/events.store.ts
+++ b/packages/plugins/auto-doc/src/stores/events.store.ts
@@ -10,10 +10,8 @@ const { pluginHostElement } = pluginStore
 
 //====== ACTIONS ======//
 function createAndDispatchActionEvent(parent: Element, element: Element, reference?: Node | null) {
-	if(reference === undefined) {
-		reference = null;
-	}
-
+	reference = reference ?? null;
+	
 	createAndDispatchEditEvent({
 		host: get(pluginHostElement),
 		edit: {
@@ -34,9 +32,7 @@ function deleteAndDispatchActionEvent(_: Element, element: Element) {
 }
 
 function moveAndDispatchActionEvent(parent: Element, element: Element, reference?: Node | null) {
-	if(reference === undefined) {
-		reference = null;
-	}
+	reference = reference ?? null;
 
 	createAndDispatchEditEvent({
 		host: get(pluginHostElement),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,12 @@ importers:
         specifier: ^1.6.2
         version: 1.6.2
     devDependencies:
+      '@oscd-plugins/core-api':
+        specifier: workspace:^
+        version: link:../../core/api
+      '@oscd-plugins/core-ui-svelte':
+        specifier: workspace:^
+        version: link:../../core/ui-svelte
       '@playwright/test':
         specifier: ^1.28.1
         version: 1.49.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,15 +258,12 @@ importers:
       '@oscd-plugins/core-api':
         specifier: workspace:^
         version: link:../../core/api
-      '@oscd-plugins/core-ui-svelte':
-        specifier: workspace:^
-        version: link:../../core/ui-svelte
       '@playwright/test':
         specifier: ^1.28.1
         version: 1.49.1
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.1
-        version: 3.1.2(svelte@4.2.19)(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))
+        version: 3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -287,7 +284,7 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^3.8.5
-        version: 3.8.6(postcss-load-config@4.0.2(postcss@8.5.2))(postcss@8.5.2)(sass@1.82.0)(svelte@4.2.19)
+        version: 3.8.6(postcss@8.4.49)(sass@1.82.0)(svelte@4.2.19)
       tslib:
         specifier: ^2.6.3
         version: 2.8.1
@@ -296,13 +293,13 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^5.4.1
-        version: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
+        version: 5.4.11(sass@1.82.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.1.1
-        version: 3.5.2(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))
+        version: 3.5.2(vite@5.4.11(sass@1.82.0))
       vitest:
         specifier: ^2.1.3
-        version: 2.1.8(@types/node@22.10.1)(happy-dom@8.9.0)(jsdom@21.1.2)(sass@1.82.0)
+        version: 2.1.8(sass@1.82.0)
 
   packages/plugins/communication-explorer:
     dependencies:
@@ -10615,6 +10612,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0)))(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))
+      debug: 4.4.0
+      svelte: 4.2.19
+      vite: 5.4.11(sass@1.82.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.1)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0)))(svelte@5.20.1)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.20.1)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0))
@@ -10649,6 +10655,20 @@ snapshots:
       svelte-hmr: 0.16.0(svelte@4.2.19)
       vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
       vitefu: 0.2.5(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0)))(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))
+      debug: 4.4.0
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.15
+      svelte: 4.2.19
+      svelte-hmr: 0.16.0(svelte@4.2.19)
+      vite: 5.4.11(sass@1.82.0)
+      vitefu: 0.2.5(vite@5.4.11(sass@1.82.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -11280,13 +11300,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))':
+  '@vitest/mocker@2.1.8(vite@5.4.11(sass@1.82.0))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.15
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
+      vite: 5.4.11(sass@1.82.0)
 
   '@vitest/mocker@3.0.5(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))':
     dependencies:
@@ -14679,14 +14699,14 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@3.8.6(postcss-load-config@4.0.2(postcss@8.5.2))(postcss@8.5.2)(sass@1.82.0)(svelte@4.2.19):
+  svelte-check@3.8.6(postcss@8.4.49)(sass@1.82.0)(svelte@4.2.19):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 4.2.19
-      svelte-preprocess: 5.1.4(postcss-load-config@4.0.2(postcss@8.5.2))(postcss@8.5.2)(sass@1.82.0)(svelte@4.2.19)(typescript@5.6.3)
+      svelte-preprocess: 5.1.4(postcss@8.4.49)(sass@1.82.0)(svelte@4.2.19)(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -14881,6 +14901,19 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.2
       postcss-load-config: 4.0.2(postcss@8.5.2)
+      sass: 1.82.0
+      typescript: 5.6.3
+
+  svelte-preprocess@5.1.4(postcss@8.4.49)(sass@1.82.0)(svelte@4.2.19)(typescript@5.6.3):
+    dependencies:
+      '@types/pug': 2.0.10
+      detect-indent: 6.1.0
+      magic-string: 0.30.15
+      sorcery: 0.11.1
+      strip-indent: 3.0.0
+      svelte: 4.2.19
+    optionalDependencies:
+      postcss: 8.4.49
       sass: 1.82.0
       typescript: 5.6.3
 
@@ -15374,13 +15407,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.8(@types/node@22.10.1)(sass@1.82.0):
+  vite-node@2.1.8(sass@1.82.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
+      vite: 5.4.11(sass@1.82.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15414,9 +15447,9 @@ snapshots:
     dependencies:
       vite: 4.5.5(@types/node@22.10.1)(sass@1.82.0)
 
-  vite-plugin-css-injected-by-js@3.5.2(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0)):
+  vite-plugin-css-injected-by-js@3.5.2(vite@5.4.11(sass@1.82.0)):
     dependencies:
-      vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
+      vite: 5.4.11(sass@1.82.0)
 
   vite-plugin-dts@4.5.0(@types/node@22.10.1)(rollup@4.34.8)(typescript@5.6.3)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0)):
     dependencies:
@@ -15466,6 +15499,15 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.82.0
 
+  vite@5.4.11(sass@1.82.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+      sass: 1.82.0
+
   vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.24.2
@@ -15485,6 +15527,10 @@ snapshots:
   vitefu@0.2.5(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0)):
     optionalDependencies:
       vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
+
+  vitefu@0.2.5(vite@5.4.11(sass@1.82.0)):
+    optionalDependencies:
+      vite: 5.4.11(sass@1.82.0)
 
   vitefu@1.0.5(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0)):
     optionalDependencies:
@@ -15578,10 +15624,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.8(@types/node@22.10.1)(happy-dom@8.9.0)(jsdom@21.1.2)(sass@1.82.0):
+  vitest@2.1.8(sass@1.82.0):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(sass@1.82.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -15597,13 +15643,9 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
-      vite-node: 2.1.8(@types/node@22.10.1)(sass@1.82.0)
+      vite: 5.4.11(sass@1.82.0)
+      vite-node: 2.1.8(sass@1.82.0)
       why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.10.1
-      happy-dom: 8.9.0
-      jsdom: 21.1.2
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
### 🗒 Description

Removes direct doc manipulation and migrates event store to V3. Resolves #366. Resolves #337. Resolves #343.

#
### 📷 Demo screen recording or Screenshots

- [x] Not applicable

# 
### 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue is linked with PR
- [x] Designated PR Reviewers are set
- [ ] Tested by another developer
- [x] Changelog updated


