### PR TITLE
[FEATURE]: Placeholder on PDF based on XPath

### DIFF
--- a/packages/plugins/auto-doc/src/plugin.svelte
+++ b/packages/plugins/auto-doc/src/plugin.svelte
@@ -20,7 +20,6 @@
 	export let editCount: number
 	
 	
-	let showBanner = true
 
 	//==== REACTIVITY ====//
 	
@@ -55,12 +54,6 @@
 <MaterialTheme pluginType={pluginType}>
 	<auto-doc class="auto-doc">
 		{#if xmlDocument}
-			{#if showBanner && !import.meta.env.DEV}
-				<div class="banner" style="{showBanner ? 'display:flex;' : 'display:none;'}">
-					This plugin is in test phase and not suitable for production use.
-					<CustomIconButton icon="close" color="white" on:click={() => showBanner = !showBanner} />
-				</div>
-			{/if}
 			<Router {routes} />
 		{:else}
 			<div class="file-missing">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,7 +269,7 @@ importers:
         version: 1.49.1
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.1
-        version: 3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))
+        version: 3.1.2(svelte@4.2.19)(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -290,7 +290,7 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^3.8.5
-        version: 3.8.6(postcss@8.4.49)(sass@1.82.0)(svelte@4.2.19)
+        version: 3.8.6(postcss-load-config@4.0.2(postcss@8.5.2))(postcss@8.5.2)(sass@1.82.0)(svelte@4.2.19)
       tslib:
         specifier: ^2.6.3
         version: 2.8.1
@@ -299,13 +299,13 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^5.4.1
-        version: 5.4.11(sass@1.82.0)
+        version: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.1.1
-        version: 3.5.2(vite@5.4.11(sass@1.82.0))
+        version: 3.5.2(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))
       vitest:
         specifier: ^2.1.3
-        version: 2.1.8(sass@1.82.0)
+        version: 2.1.8(@types/node@22.10.1)(happy-dom@8.9.0)(jsdom@21.1.2)(sass@1.82.0)
 
   packages/plugins/communication-explorer:
     dependencies:
@@ -10618,15 +10618,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0)))(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))
-      debug: 4.4.0
-      svelte: 4.2.19
-      vite: 5.4.11(sass@1.82.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.1)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0)))(svelte@5.20.1)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.20.1)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0))
@@ -10661,20 +10652,6 @@ snapshots:
       svelte-hmr: 0.16.0(svelte@4.2.19)
       vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
       vitefu: 0.2.5(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.11(sass@1.82.0)))(svelte@4.2.19)(vite@5.4.11(sass@1.82.0))
-      debug: 4.4.0
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.15
-      svelte: 4.2.19
-      svelte-hmr: 0.16.0(svelte@4.2.19)
-      vite: 5.4.11(sass@1.82.0)
-      vitefu: 0.2.5(vite@5.4.11(sass@1.82.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -11306,13 +11283,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11(sass@1.82.0))':
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.15
     optionalDependencies:
-      vite: 5.4.11(sass@1.82.0)
+      vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
 
   '@vitest/mocker@3.0.5(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))':
     dependencies:
@@ -14705,14 +14682,14 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@3.8.6(postcss@8.4.49)(sass@1.82.0)(svelte@4.2.19):
+  svelte-check@3.8.6(postcss-load-config@4.0.2(postcss@8.5.2))(postcss@8.5.2)(sass@1.82.0)(svelte@4.2.19):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 4.2.19
-      svelte-preprocess: 5.1.4(postcss@8.4.49)(sass@1.82.0)(svelte@4.2.19)(typescript@5.6.3)
+      svelte-preprocess: 5.1.4(postcss-load-config@4.0.2(postcss@8.5.2))(postcss@8.5.2)(sass@1.82.0)(svelte@4.2.19)(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -14907,19 +14884,6 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.2
       postcss-load-config: 4.0.2(postcss@8.5.2)
-      sass: 1.82.0
-      typescript: 5.6.3
-
-  svelte-preprocess@5.1.4(postcss@8.4.49)(sass@1.82.0)(svelte@4.2.19)(typescript@5.6.3):
-    dependencies:
-      '@types/pug': 2.0.10
-      detect-indent: 6.1.0
-      magic-string: 0.30.15
-      sorcery: 0.11.1
-      strip-indent: 3.0.0
-      svelte: 4.2.19
-    optionalDependencies:
-      postcss: 8.4.49
       sass: 1.82.0
       typescript: 5.6.3
 
@@ -15427,13 +15391,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.8(sass@1.82.0):
+  vite-node@2.1.8(@types/node@22.10.1)(sass@1.82.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11(sass@1.82.0)
+      vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15467,9 +15431,9 @@ snapshots:
     dependencies:
       vite: 4.5.5(@types/node@22.10.1)(sass@1.82.0)
 
-  vite-plugin-css-injected-by-js@3.5.2(vite@5.4.11(sass@1.82.0)):
+  vite-plugin-css-injected-by-js@3.5.2(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0)):
     dependencies:
-      vite: 5.4.11(sass@1.82.0)
+      vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
 
   vite-plugin-dts@4.5.0(@types/node@22.10.1)(rollup@4.34.8)(typescript@5.6.3)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0)):
     dependencies:
@@ -15519,15 +15483,6 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.82.0
 
-  vite@5.4.11(sass@1.82.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.28.1
-    optionalDependencies:
-      fsevents: 2.3.3
-      sass: 1.82.0
-
   vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.24.2
@@ -15547,10 +15502,6 @@ snapshots:
   vitefu@0.2.5(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0)):
     optionalDependencies:
       vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
-
-  vitefu@0.2.5(vite@5.4.11(sass@1.82.0)):
-    optionalDependencies:
-      vite: 5.4.11(sass@1.82.0)
 
   vitefu@1.0.5(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0)):
     optionalDependencies:
@@ -15644,10 +15595,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.8(sass@1.82.0):
+  vitest@2.1.8(@types/node@22.10.1)(happy-dom@8.9.0)(jsdom@21.1.2)(sass@1.82.0):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(sass@1.82.0))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.1)(sass@1.82.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -15663,9 +15614,13 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(sass@1.82.0)
-      vite-node: 2.1.8(sass@1.82.0)
+      vite: 5.4.11(@types/node@22.10.1)(sass@1.82.0)
+      vite-node: 2.1.8(@types/node@22.10.1)(sass@1.82.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.10.1
+      happy-dom: 8.9.0
+      jsdom: 21.1.2
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
### 🗒 Description

The user is able to create a placeholder that shall be filled with values from the XML file. 
This placeholder search pattern is based on a given XPath provided by the user.

For Example: 

Sample XML:
``` XML
<SCL>
 <Substation desc="NRW_Sub" name="Bonn101">
   <Bay desc="-first desc" name="DO">...</Bay>
   <Bay desc="-second desc" name="RE">...</Bay>
   <Bay desc="-thrd desc" name="MI">...</Bay>
 </Substation>
</SCL>
```
-----------------------

```
XPath Placeholder:
The third Bay name is: {{//default:Bay[3]/@name}}

Output:
The third Bay name is: MI
```

```
XPath Placeholder:
Substation {{//default:Substation/@name}} has grown quite large

Output:
Substation Bonn101 has grown quite large
```

-----------------------
Disclaimer: 
It is important to provide the "**{{...}}**", only then we know to fill in the placeholder.
Also, always provide a **namespace** for the search. So far, all the SCD files that I have, worked with the **default:** namespace.
If no namespace is provided, there is no guarantee that a value can be found. Most SCDs operate under a namespace **(xmlns="http://www.iec.ch/61850/2003/SCL")**

# 
### 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [ ] Ticket-ACs are checked and met
- [ ] GitHub **labels** are assigned
- [ ] Git Ticket / issue  is linked with PR
- [ ] Designated PR Reviewers are set
- [ ] Tested by another developer
- [ ] Changelog updated
- [ ] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading )
- [ ] All comments in the PR are resolved / answered
#
### 🔦 Useful commits

You can add specific commits which are worth taking a look into

