### PR TITLE
[FEATURE]: Disable template import when is "Master" template

### DIFF
--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2025-03-28
+
+### Added
+
+- Master template flag on SCD file
+- Disable import template function when it's a master template
+ 
 ## [1.13.0] - 2025-03-26
 
 ### Added

--- a/packages/plugins/auto-doc/package.json
+++ b/packages/plugins/auto-doc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/auto-doc",
 	"private": true,
-	"version": "1.13.0",
+	"version": "1.14.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite --mode STAND_ALONE",

--- a/packages/plugins/auto-doc/src/pages/template-overview/template-overview.svelte
+++ b/packages/plugins/auto-doc/src/pages/template-overview/template-overview.svelte
@@ -123,12 +123,12 @@
                 <Item on:SMUI:action={() => openFileSelectorIfNotMasterTemplate()}
                     title={importToolTipText}
                 >
-                    <Text class={isMasterTemplate ? "strike-through": ""}>Import from</Text>
+                    <Text class={isMasterTemplate ? "cursor-not-allowed": ""}>Import from</Text>
                 </Item>
             </List>
         </Menu>
         <!-- <Button variant="outlined" class="btn-pill btn-pill-outlined">Generate Document</Button> -->
-         <div class="master-template-checkbox">
+         <div class="master-template-checkbox-area">
             <Checkbox bind:checked={isMasterTemplate} />
             <span>Master Template</span>
          </div>
@@ -182,12 +182,12 @@
         }
     }
 
-    .master-template-checkbox{
+    .master-template-checkbox-area{
         display: flex;
         align-items: center;
     }
 
-    :global(.strike-through){
+    :global(.cursor-not-allowed){
         cursor: not-allowed;
         color: #a6a6a6;
     }

--- a/packages/plugins/auto-doc/src/pages/template-overview/template-overview.svelte
+++ b/packages/plugins/auto-doc/src/pages/template-overview/template-overview.svelte
@@ -55,6 +55,7 @@
 
     $: templatesConvertedToTableRow = allTemplates.map(mapElementToTableRow)
     $: docTemplatesStore.setMasterTemplateFlag(isMasterTemplate)
+    $: importToolTipText = isMasterTemplate ? "No import allowed for master templates" : ""
 
 
     function mapElementToTableRow(template: Element):Template{
@@ -119,7 +120,9 @@
                 <Item on:SMUI:action={() => navigateToCreateTemplate()}>
                     <Text>New</Text>
                 </Item>
-                <Item on:SMUI:action={() => openFileSelectorIfNotMasterTemplate()}>
+                <Item on:SMUI:action={() => openFileSelectorIfNotMasterTemplate()}
+                    title={importToolTipText}
+                >
                     <Text class={isMasterTemplate ? "strike-through": ""}>Import from</Text>
                 </Item>
             </List>
@@ -186,7 +189,6 @@
 
     :global(.strike-through){
         cursor: not-allowed;
-        text-decoration: line-through;
-        color: gray;
+        color: #a6a6a6;
     }
 </style>

--- a/packages/plugins/auto-doc/src/pages/template-overview/template-overview.svelte
+++ b/packages/plugins/auto-doc/src/pages/template-overview/template-overview.svelte
@@ -120,7 +120,7 @@
                     <Text>New</Text>
                 </Item>
                 <Item on:SMUI:action={() => openFileSelectorIfNotMasterTemplate()}>
-                    <Text>Import from</Text>
+                    <Text class={isMasterTemplate ? "strike-through": ""}>Import from</Text>
                 </Item>
             </List>
         </Menu>
@@ -182,5 +182,11 @@
     .master-template-checkbox{
         display: flex;
         align-items: center;
+    }
+
+    :global(.strike-through){
+        cursor: not-allowed;
+        text-decoration: line-through;
+        color: gray;
     }
 </style>

--- a/packages/plugins/auto-doc/src/pages/template-overview/template-overview.svelte
+++ b/packages/plugins/auto-doc/src/pages/template-overview/template-overview.svelte
@@ -5,6 +5,7 @@
     import Button, {Label} from "@smui/button"
     import Menu from "@smui/menu"
     import List, { Item, Text } from "@smui/list"
+    import Checkbox from '@smui/checkbox';
     import {IconWrapper} from "@oscd-plugins/ui"
     import {docTemplatesStore} from '@/stores'
     import {push} from 'svelte-spa-router'
@@ -15,7 +16,7 @@
 
     let menu: Menu
     let fileSelector: FileSelector
-
+    let isMasterTemplate = docTemplatesStore.getMasterTemplateFlag()
     let allTemplates: Element[] = []
     const emptyTitleOrDescription = "N/A"
 
@@ -53,6 +54,7 @@
 
 
     $: templatesConvertedToTableRow = allTemplates.map(mapElementToTableRow)
+    $: docTemplatesStore.setMasterTemplateFlag(isMasterTemplate)
 
 
     function mapElementToTableRow(template: Element):Template{
@@ -91,6 +93,14 @@
        fetchTemplates();
     }
 
+    function openFileSelectorIfNotMasterTemplate(){
+        if(isMasterTemplate){
+            console.error("No import allowed for master templates")
+            return;
+        }
+        fileSelector.open();
+    }
+
 
 
 
@@ -109,12 +119,17 @@
                 <Item on:SMUI:action={() => navigateToCreateTemplate()}>
                     <Text>New</Text>
                 </Item>
-                <Item on:SMUI:action={() => fileSelector.open()}>
+                <Item on:SMUI:action={() => openFileSelectorIfNotMasterTemplate()}>
                     <Text>Import from</Text>
                 </Item>
             </List>
         </Menu>
         <!-- <Button variant="outlined" class="btn-pill btn-pill-outlined">Generate Document</Button> -->
+         <div class="master-template-checkbox">
+            <Checkbox bind:checked={isMasterTemplate} />
+            <span>Master Template</span>
+         </div>
+
     </header>  
     <main>
         <Table 
@@ -138,6 +153,8 @@
     }
     .template-controls{
         margin: 0 0 1rem 1rem;
+        display: flex;
+        justify-content: space-between;
         & :global(.btn-pill){
                 border-radius: 2em;
                 cursor: pointer;
@@ -160,5 +177,10 @@
                 background-color:$clr-secondary-15;
             }
         }
+    }
+
+    .master-template-checkbox{
+        display: flex;
+        align-items: center;
     }
 </style>

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.spec.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.spec.ts
@@ -575,6 +575,19 @@ describe('DocumentTemplateStore', () => {
 		const autoDocArea = get(docTemplatesStore.privateArea);
 		expect(eventStore.createMultipleAndDispatchActionEvent).toHaveBeenCalledWith(autoDocArea, templates, 'Import auto doc templates');
 	  });
+
+	  it('should set master template flag and dispatch event', () => {
+		vi.spyOn(eventStore, 'updateAndDispatchActionEvent');
+		const isMaster = true
+		docTemplatesStore.setMasterTemplateFlag(isMaster);
+
+		const autoDocArea = get(docTemplatesStore.privateArea);
+
+		const updates = { masterTemplate: isMaster.toString(), type: 'AUTO_DOC' }
+
+		expect(eventStore.updateAndDispatchActionEvent).toHaveBeenCalledWith(autoDocArea, updates);
+	  });
+
 });
 
 

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
@@ -36,11 +36,6 @@ function createAutoDocArea(xmlDocument: Document): Element {
     return newPrivateArea;
 }
 function getAutoDocArea() {
-    const xmlDoc = get(xmlDocument);
-    if (!xmlDoc) {
-        throw new Error("XML Document is not defined");
-    }
-
     const privateArea = get(autoDocArea);
     if (!privateArea) {
         throw new Error("AutoDoc area is not defined");

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
@@ -31,10 +31,22 @@ function createAutoDocArea(xmlDocument: Document): Element {
     if (existingAutoDocArea) {
         return existingAutoDocArea;
     }
-
     const newPrivateArea = createElement(xmlDocument, 'Private', { type: 'AUTO_DOC' });
     eventStore.createAndDispatchActionEvent(rootElement, newPrivateArea);
     return newPrivateArea;
+}
+function getAutoDocArea() {
+    const xmlDoc = get(xmlDocument);
+    if (!xmlDoc) {
+        throw new Error("XML Document is not defined");
+    }
+
+    const privateArea = get(autoDocArea);
+    if (!privateArea) {
+        throw new Error("AutoDoc area is not defined");
+    }
+
+    return privateArea;
 }
 
 //==== PUBLIC ACTIONS
@@ -235,6 +247,22 @@ function duplicateDocumentTemplate(docTemplateId: string) {
     }
 }
 
+function setMasterTemplateFlag(isMaster: boolean) {
+    const currentPrivateArea = getAutoDocArea();
+
+    const updates : {masterTemplate: string, type: string} = { masterTemplate: String(isMaster), type: 'AUTO_DOC' }
+    eventStore.updateAndDispatchActionEvent(currentPrivateArea, updates);
+}
+
+function getMasterTemplateFlag() : boolean {
+    const currentPrivateArea = getAutoDocArea()
+
+    const flag = currentPrivateArea.getAttribute('masterTemplate');
+
+    if(!flag) {return false}
+
+    return flag === 'true';
+}
 //==== INITIALIZATION
 function init() {
     setAutoDocArea();
@@ -259,4 +287,6 @@ export const docTemplatesStore = {
     duplicateDocumentTemplate,
     importDocumentTemplates,
     duplicateBlockFromDocumentTemplate,
+    setMasterTemplateFlag,
+    getMasterTemplateFlag
 };

--- a/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
+++ b/packages/plugins/auto-doc/src/stores/doc-templates.store.ts
@@ -250,7 +250,7 @@ function duplicateDocumentTemplate(docTemplateId: string) {
 function setMasterTemplateFlag(isMaster: boolean) {
     const currentPrivateArea = getAutoDocArea();
 
-    const updates : {masterTemplate: string, type: string} = { masterTemplate: String(isMaster), type: 'AUTO_DOC' }
+    const updates : {masterTemplate: string, type: string} = { masterTemplate: isMaster.toString(), type: 'AUTO_DOC' }
     eventStore.updateAndDispatchActionEvent(currentPrivateArea, updates);
 }
 


### PR DESCRIPTION
# 🗒 Description

Added a tag to recognize when a file is a template file or not.
On template files, it is not possible to import from another file

## 📷 Demo screen recording or Screenshots

Case #1: Master Template

https://github.com/user-attachments/assets/d1101a5b-3e73-4f45-8962-f1fb43179455

Case #2: Normal SCD file


https://github.com/user-attachments/assets/922ae57d-6b88-485c-862e-b6c10f6f3425


## 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [x] Designated PR Reviewers are set
- [ ] Tested by another developer
- [x] Changelog updated
- [ ] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading)
- [ ] All comments in the PR are resolved / answered

## 🔦 Useful commits

You can add specific commits which are worth taking a look into

## ❌ Link issue(s) to close - [hint](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

You can add specific commits which are worth taking a look into

