### PR TITLE
Feat: UX Adjustments in IO Center (2)

### DIFF
--- a/packages/plugins/io-center/src/ied/ied-select.svelte
+++ b/packages/plugins/io-center/src/ied/ied-select.svelte
@@ -21,7 +21,7 @@
 	}
 </script>
 
-<div class="flex-col mx-auto w-4/5 mt-2">
+<div class="flex-col mx-auto w-full px-2 mt-2">
 	<label for="select" class="font-medium">Select an IED</label>
 	<select
 		id="select"

--- a/packages/plugins/io-center/src/ied/ied-select.svelte
+++ b/packages/plugins/io-center/src/ied/ied-select.svelte
@@ -38,3 +38,15 @@
 		{/each}
 	</select>
 </div>
+
+<style>
+	select {
+		background: url("data:image/svg+xml,<svg height='10px' width='10px' viewBox='0 0 16 16' fill='%23000000' xmlns='http://www.w3.org/2000/svg'><path d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>") no-repeat;
+		background-position: calc(100% - 0.75rem) center !important;
+		-moz-appearance:none !important;
+		-webkit-appearance: none !important; 
+		appearance: none !important;
+		padding-right: 2rem !important;
+		background-color: #FAFAFA;
+	}
+</style>


### PR DESCRIPTION
# 🗒 Description

This the second part of #390 which has been split up.

The IED Select dropdown now takes up the full available width. Its system default chevron down icon has been replaced by a custom SVG that has the correct padding.

## 📷 Demo screen recording or Screenshots

### Dropdown
<img width="317" alt="Screenshot 2025-03-31 at 11 13 07 AM" src="https://github.com/user-attachments/assets/c0034d3a-c785-430f-a45b-a193aea0dab4" />

## 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Designated PR Reviewers are set
- [ ] Tested by another developer
