### PR TITLE
Fix: Open SCD in overview

### DIFF
--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.1] - 2025-04-15
+
+### Fixed
+
+- Images cut in PDF export
+
 ## [1.16.0] - 2025-03-31
 
 ### Added

--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.17.0] - 2025-04-23
+## [1.16.2] - 2025-04-23
 
 ### Fixed
 

--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.16.2] - 2025-04-23
+## [1.16.2] - 2025-04-25
 
 ### Fixed
 

--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2025-04-23
+
+### Fixed
+
+- Open SCD files in overiew instead of edit view
+
 ## [1.16.1] - 2025-04-15
 
 ### Fixed

--- a/packages/plugins/auto-doc/package.json
+++ b/packages/plugins/auto-doc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/auto-doc",
 	"private": true,
-	"version": "1.16.0",
+	"version": "1.16.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite --mode STAND_ALONE",

--- a/packages/plugins/auto-doc/package.json
+++ b/packages/plugins/auto-doc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/auto-doc",
 	"private": true,
-	"version": "1.17.0",
+	"version": "1.16.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite --mode STAND_ALONE",

--- a/packages/plugins/auto-doc/package.json
+++ b/packages/plugins/auto-doc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/auto-doc",
 	"private": true,
-	"version": "1.16.1",
+	"version": "1.17.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite --mode STAND_ALONE",

--- a/packages/plugins/auto-doc/src/pages/template-creation/template-creation.svelte
+++ b/packages/plugins/auto-doc/src/pages/template-creation/template-creation.svelte
@@ -29,6 +29,8 @@
             return navigateToOverviewPage();
         }
 
+        window.history.pushState({}, "", "#");
+
         setInitialTitleAndDescription(template);
     });
 

--- a/packages/plugins/auto-doc/src/utils/pdfGenerator.ts
+++ b/packages/plugins/auto-doc/src/utils/pdfGenerator.ts
@@ -42,6 +42,11 @@ async function generatePdf(templateTitle: string , allBlocks: Element[]){
         return (marginTop + bufferToBottomPage) > (pageHeight-marginBottom);
     }
 
+    function createNewPage() {
+        doc.addPage();
+        marginTop = INITIAL_UPPER_PAGE_COORDINATE; 
+    }
+
     function handleRichTextEditorBlock(block: Element){
         const parser = new DOMParser();
         const parsedBlockContent = parser.parseFromString(block.textContent ?? "", "text/html");
@@ -88,9 +93,9 @@ async function generatePdf(templateTitle: string , allBlocks: Element[]){
 
         for(const line of wrappedText){
             if (contentExceedsCurrentPage()) {
-                doc.addPage();
-                marginTop = INITIAL_UPPER_PAGE_COORDINATE; 
+                createNewPage();
             }
+
             const horizontalSpacing = 10;
             doc.text(line, horizontalSpacing, marginTop);
             incrementVerticalPositionForNextLine();
@@ -151,8 +156,7 @@ async function generatePdf(templateTitle: string , allBlocks: Element[]){
   
     function renderTextLine(text: string) {
         if (contentExceedsCurrentPage()) {
-            doc.addPage();
-            marginTop = INITIAL_UPPER_PAGE_COORDINATE;
+            createNewPage();
         }
         const horizontalSpacing = 10;
         doc.text(text, horizontalSpacing, marginTop);
@@ -206,6 +210,10 @@ async function generatePdf(templateTitle: string , allBlocks: Element[]){
         const width = scaleFactor * maxWidth;
         const height = width * aspectRatio;
 
+        if(contentExceedsCurrentPage(height)) {
+            createNewPage();
+        }
+
         doc.addImage(imageSource, format.toUpperCase(), 10, marginTop, width, height);
         
         const padding = Math.round(height) + DEFAULT_LINE_HEIGHT;
@@ -240,7 +248,7 @@ async function generatePdf(templateTitle: string , allBlocks: Element[]){
             }
         }
 
-       renderTextLine(pdfHintText);
+        renderTextLine(pdfHintText);
         zipcelx(config)
     }
 
@@ -314,8 +322,7 @@ async function generatePdf(templateTitle: string , allBlocks: Element[]){
 
         const tableHeight = (rows * DEFAULT_LINE_HEIGHT + DEFAULT_LINE_HEIGHT);
         if(contentExceedsCurrentPage(tableHeight)) {
-            doc.addPage();            
-            marginTop = INITIAL_UPPER_PAGE_COORDINATE;
+            createNewPage();
         } else {
             incrementVerticalPositionForNextLine(tableHeight);
         }


### PR DESCRIPTION
# 🗒 Description

Load an SCD file. Click on the edit button to go inside the template. Reload the page. Load the file again. You'll notice that before, you were being sent straight to the edit view, which is not the intended way. This PR fixes that issue.

## 📷 Demo screen recording or Screenshots

- [x] Not applicable

## 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [ ] Ticket-ACs are checked and met
- [ ] GitHub **labels** are assigned
- [ ] Git Ticket / issue  is linked with PR
- [ ] Designated PR Reviewers are set
- [ ] Tested by another developer
- [ ] Changelog updated
- [ ] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading )
- [ ] All comments in the PR are resolved / answered

## 🔦 Useful commits

You can add specific commits which are worth taking a look into

## ❌ Link issue(s) to close - [hint](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

Resolves #421.