### PR TITLE
feat(type-designer): optimize dnd (opening time + last item flicker)

### DIFF
--- a/packages/plugins/type-designer/src/ui/components/column/single-column.svelte
+++ b/packages/plugins/type-designer/src/ui/components/column/single-column.svelte
@@ -22,7 +22,6 @@ import {
 	ALLOWED_TARGETS_BY_TYPE_FAMILY,
 	TYPE_FAMILY
 } from '@/headless/constants'
-import type { SvelteComponent } from 'svelte'
 
 //======= INITIALIZATION =======//
 
@@ -37,7 +36,7 @@ const {
 
 //======= STATES =======//
 
-let columnContentElement = $state<SvelteComponent | null>(null)
+let columnContentElement = $state<HTMLElement | null>(null)
 
 //====== DERIVED STATES ======//
 
@@ -119,7 +118,7 @@ const isColumnDisabled = $derived.by(() => {
 		</Input.Root>
 	</Card.Header>
 
-	<Card.Content class="pb-0 px-2 pt-4 overflow-y-hidden h-full flex flex-col" bind:this={columnContentElement}>
+	<Card.Content class="pb-0 px-2 pt-4 overflow-y-hidden h-full flex flex-col">
 
 		{#if isImportViewActive}
 			<div
@@ -131,10 +130,11 @@ const isColumnDisabled = $derived.by(() => {
 		{/if}	
 		
 		{#if hasTypeElements}
-			<div class={`${isImportViewActive ? "h-1/4" : "flex-1"} overflow-y-auto p-2`}>
+			<div class={`${isImportViewActive ? "h-1/4" : "flex-1"} overflow-y-auto p-2`} bind:this={columnContentElement}>
 				{#each groupedTypeElementsEntries as [typeElementFamily, typeElements]}
-					{#each Object.entries(typeElements) as [typeElementKey, typeElement] (typeElementKey)}
-						<CardCollapsibleWrapper {typeElementKey} {typeElement} {typeElementFamily}/>
+					{@const typeElementsEntries = Object.entries(typeElements)}
+					{#each typeElementsEntries as [typeElementKey, typeElement], index (typeElementKey)}
+						<CardCollapsibleWrapper {typeElementKey} {typeElement} {typeElementFamily} isLast={typeElementsEntries.length === index +1} {columnContentElement}/>
 					{/each}
 				{/each}
 			</div>

--- a/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
+++ b/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
@@ -30,12 +30,16 @@ const {
 	typeElementKey,
 	typeElementFamily,
 	typeElement,
-	importScope
+	importScope,
+	isLast,
+	columnContentElement
 }: {
 	typeElementKey: string
 	typeElementFamily: AvailableTypeFamily
 	typeElement: TypeElement<AvailableTypeFamily>
 	importScope?: ImportScope
+	isLast: boolean
+	columnContentElement?: HTMLElement | null
 } = $props()
 
 // local states
@@ -128,7 +132,7 @@ const handleOpenCollapsible = (event: DragEvent) => {
 			isElementCardOpen = true
 			if (!hasRefs) isCurrentDropTarget = true
 			hoverTimeout = null
-		}, 500)
+		}, 200)
 }
 
 const handleCloseCollapsible = (event: DragEvent) => {
@@ -161,6 +165,14 @@ const handleDragLeave = (event: DragEvent) => {
 $effect(() => {
 	if (!hasRefs) isElementCardOpen = false
 })
+
+// handle last element with drag and drop
+// to scroll the column content element
+$effect(() => {
+	const invisiblePlaceholderHeightInPixels = 32
+	if (isElementCardOpen && isLast && columnContentElement)
+		columnContentElement.scrollTop += invisiblePlaceholderHeightInPixels
+})
 </script>
 
 <Collapsible.Root 
@@ -168,9 +180,9 @@ $effect(() => {
 	class="space-y-1 mb-2"
 	ondragover={importScope ? undefined : handleOpenCollapsible}
 	ondragleave={importScope ? undefined : handleCloseCollapsible}
+	ondrop={importScope ? undefined : handleCloseCollapsible}
 >
 	<TypeCard {typeElement} {typeElementKey} {typeElementFamily} {isElementCardOpen} {importScope} />
-
 
 	<Collapsible.Content class="space-y-1 flex flex-col items-end relative"
 		ondragover={handleDragOver}


### PR DESCRIPTION
# 🗒 Description

**Changed**

- Drag'n'Drop opening time on elements card (from 500 to 200 ms)
-> based on #457 

**Fixed**

- Scrollbar adjust its position for the last type element item in the list, so that it is now possible to easily drop elements.
-> simplified approach compared to #457

