### PR TITLE
Feat(type-designer): Bay template always on top by import

### DIFF
--- a/packages/plugins/type-designer/CHANGELOG.md
+++ b/packages/plugins/type-designer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.0] - 06.06.2025
+
+### Added
+
+- Imported bays are always written after the `Bay[name="Template"]`
+
 ## [3.13.0] - 06.06.2025
 
 ### Added

--- a/packages/plugins/type-designer/package.json
+++ b/packages/plugins/type-designer/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/type-designer",
 	"private": true,
-	"version": "3.13.0",
+	"version": "3.14.0",
 	"type": "module",
 	"source": "src/plugin.ts",
 	"scripts": {

--- a/packages/plugins/type-designer/src/headless/stores/imports/imported-tree-handler.helper.ts
+++ b/packages/plugins/type-designer/src/headless/stores/imports/imported-tree-handler.helper.ts
@@ -208,11 +208,14 @@ function getLocalNextSibling(
 	localParent: Element
 ) {
 	const currentTagName = currentImportedElement.tagName
-	const lastOfItsLocalKind =
-		Array.from(localParent.getElementsByTagName(currentTagName)).at(-1) ||
-		null
+	const lastOfItsLocalKind = Array.from(
+		localParent.getElementsByTagName(currentTagName)
+	).at(-1)
 
-	return lastOfItsLocalKind
+	const nextSiblingOfLastOfItsLocalKind =
+		lastOfItsLocalKind?.nextElementSibling || null
+
+	return nextSiblingOfLastOfItsLocalKind
 }
 
 async function getElementActionPayload(currentImportedElement: Element) {


### PR DESCRIPTION
# 🗒 Description

**Added**

- Imported bays are always written after the `Bay[name="Template"]`

## ❌ Link issue(s) to close - [hint](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

Closes #470 

