### PR TITLE
Fix(type designer): import naming duplicate name

### DIFF
--- a/packages/plugins/type-designer/CHANGELOG.md
+++ b/packages/plugins/type-designer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.1] - 06.06.2025
+
+### Fixed
+
+- Import naming on duplicate elements
+
 ## [3.14.0] - 06.06.2025
 
 ### Added

--- a/packages/plugins/type-designer/package.json
+++ b/packages/plugins/type-designer/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/type-designer",
 	"private": true,
-	"version": "3.14.0",
+	"version": "3.14.1",
 	"type": "module",
 	"source": "src/plugin.ts",
 	"scripts": {

--- a/packages/plugins/type-designer/src/headless/stores/imports/imported-tree-handler.helper.ts
+++ b/packages/plugins/type-designer/src/headless/stores/imports/imported-tree-handler.helper.ts
@@ -79,6 +79,11 @@ async function addReplaceAction(
 	if (!elementToRemove) throw new Error('Element to remove is not defined')
 
 	setUuidAttributesRecursively(elementToReplace)
+	if (
+		elementToReplace.getAttribute('name') !==
+		elementToRemove.getAttribute('name')
+	)
+		setNameAttribute(elementToReplace)
 
 	const { idOrUuid, localParent, localNextSibling } =
 		await getElementActionPayload(currentImportedElement)

--- a/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
+++ b/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
@@ -167,11 +167,13 @@ $effect(() => {
 })
 
 // handle last element with drag and drop
-// to scroll the column content element
+// to scroll the column content element to bottom
 $effect(() => {
-	const invisiblePlaceholderHeightInPixels = 32
 	if (isElementCardOpen && isLast && columnContentElement)
-		columnContentElement.scrollTop += invisiblePlaceholderHeightInPixels
+		columnContentElement.scrollTo({
+			top: columnContentElement.scrollHeight,
+			behavior: 'smooth'
+		})
 })
 </script>
 


### PR DESCRIPTION
# 🗒 Description

**Fixed**

- Import naming on duplicate elements

## ❌ Link issue(s) to close - [hint](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

Closes #472 
