### PR TITLE
Feat/type designer/keep refs on already imported type element

### DIFF
--- a/packages/plugins/type-designer/CHANGELOG.md
+++ b/packages/plugins/type-designer/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [3.15.0] - 06.06.2025
+
+### Added
+
+- Type refs are always visible in the import container (even after importing a linked type)
+
 ## [3.14.1] - 06.06.2025
 
 ### Fixed

--- a/packages/plugins/type-designer/package.json
+++ b/packages/plugins/type-designer/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/type-designer",
 	"private": true,
-	"version": "3.14.1",
+	"version": "3.15.0",
 	"type": "module",
 	"source": "src/plugin.ts",
 	"scripts": {

--- a/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
+++ b/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
@@ -51,12 +51,19 @@ let hoverTimeout: NodeJS.Timeout | null = $state(null)
 
 const isLNodeType = $derived(typeElementFamily === TYPE_FAMILY.lNodeType)
 
-const currentRefs = $derived(
-	Object.entries(typeElement.refs) as [
+const currentRefs = $derived.by(() => {
+	if (importScope)
+		return Object.entries(
+			importsStore.loadedTypeElementsPerFamily[typeElementFamily].raw[
+				typeElementKey
+			].refs
+		) as [AvailableRefFamily, RefElementByIds<AvailableRefFamily>][]
+
+	return Object.entries(typeElement.refs) as [
 		AvailableRefFamily,
 		RefElementByIds<AvailableRefFamily>
 	][]
-)
+})
 
 const hasRefs = $derived.by(() => {
 	return Object.values(typeElement.refs).some(
@@ -162,6 +169,7 @@ const handleDragLeave = (event: DragEvent) => {
 
 //======= EFFECTS =======//
 
+// autoclose collapsible if no refs are present
 $effect(() => {
 	if (!hasRefs) isElementCardOpen = false
 })

--- a/packages/plugins/type-designer/src/ui/components/import/import-container.svelte
+++ b/packages/plugins/type-designer/src/ui/components/import/import-container.svelte
@@ -121,7 +121,7 @@ function hasLoadedTypeElements(scope: 'all' | ImportScope) {
 
 {#snippet importOptions(scope: 'all' | ImportScope)}
 <div class="flex flex-col h-full">
-	<Card.Content class="px-0 pt-4 overflow-y-auto flex-1 pb-0">
+	<Card.Content class="px-1.5 pt-4 overflow-y-auto flex-1 pb-0">
 		{#if hasLoadedTypeElementsPerScope[scope] }
 			{#each groupedLoadedTypeElementsEntries as [typeElementFamily, typeElements]}
 				{#if scope === 'all'}


### PR DESCRIPTION
# 🗒 Description

**Added**

- Type refs are always visible in the import container (even after importing a linked type)

## ❌ Link issue(s) to close - [hint](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

Closes #471 
