### PR TITLE
Feat/ce/svelte 5 migration

### DIFF
--- a/packages/core/ui-svelte/package.json
+++ b/packages/core/ui-svelte/package.json
@@ -79,5 +79,8 @@
 		"vaul-svelte": "1.0.0-next.3",
 		"vite": "6.1.0",
 		"zod": "^3.24.1"
+	},
+	"dependencies": {
+		"@xyflow/svelte": "^1.2.1"
 	}
 }

--- a/packages/core/ui-svelte/src/lib/headless/actions/useInitPlugin.svelte.ts
+++ b/packages/core/ui-svelte/src/lib/headless/actions/useInitPlugin.svelte.ts
@@ -7,6 +7,7 @@ import inlineCssLegacyTheme from '$lib/theme/styles/legacy-oscd-instance.theme.c
 import inlineCssShadcnTheme from '$lib/theme/styles/shadcn-stock.theme.css?inline'
 import inlineCssFonts from '$lib/theme/styles/fonts.css?inline'
 import inlineShadCnAdaptation from '$lib/theme/styles/shadcn-adaptation-to-instance-specificities.css?inline'
+import svelteFlowTheme from '@xyflow/svelte/dist/style.css?inline'
 // COMPONENTS
 import { Toaster } from '$lib/ui/shadcn/sonner/index.js'
 // UTILS
@@ -20,6 +21,7 @@ export function initPlugin(
 	node: HTMLElement,
 	params: {
 		theme: 'legacy-oscd-instance' | 'shadcn-stock'
+		useSvelteFlowTheme?: boolean
 		getDoc: () => XMLDocument
 		getDocName: () => string
 		getEditCount: () => number
@@ -32,6 +34,7 @@ export function initPlugin(
 		}
 		getHost: () => HTMLElement | undefined
 		customNamespaces?: Record<'namespacePrefix' | 'namespaceUri', string>[]
+
 	}
 ) {
 	const isInitialized = $derived(
@@ -46,6 +49,9 @@ export function initPlugin(
 	const docName = $derived(params.getDocName())
 	const editCount = $derived(params.getEditCount())
 	const isCustomInstance = $derived(params.getIsCustomInstance())
+	const isUsingSvelteFlowTheme = $derived(
+		params.useSvelteFlowTheme ?? false
+	)
 	const host = $derived(params.getHost())
 	const rootElement = $derived(doc?.documentElement)
 
@@ -246,9 +252,10 @@ export function initPlugin(
 			node.insertAdjacentElement('beforebegin', style)
 
 			style.innerHTML = `
+				${isUsingSvelteFlowTheme ? svelteFlowTheme : ''}
 				${selectedTheme}
 				${inlineCssFonts}
-				${inlineShadCnAdaptation}
+				${inlineShadCnAdaptation} 
 				main {
 					${cssVariables};
 					font-family: "Roboto", sans-serif;

--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -7,19 +7,22 @@
 - [] Modify the imported mock file imported in `src` > `plugin.dev.ts` to a `SCD`file that suits your needs
 - [] Launch `pnpm i`
 - [] Add if needed launch scripts to the monorepo package.json as shortcuts
+- [] Change `vite.config.ts` ports to a random one (both `server` and `preview`)
 
 ## LAUNCH SCRIPT
 
-1. Stand alone mode : `pnpm dev`
+1. Stand alone mode :
 
+* Launch the plugin with : `pnpm dev`
 In this mode the plugin is launched with HRM and locally with a mocked file already loaded
 
 2. Integrated mode with an SCD Instance : `pnpm integrated`
 
-In this mode the plugin has to be implemented with the given url in the console.
-The plugin is build, and then launched in a preview mode.
-Copy the given URL to your test instance : `${URL}/${buildJSFilename}.js`
-The `buildJSFilename` is the one provided in the `vite.config` : here `plugin.js` by default.
+* Launch the plugin with : `pnpm dev`
+* Copy the given url and add this : `${URL}/src/plugin.js`.
+* Load the plugin in OpenSCD with this url.
+
+It gives you HMR ability inside the OpenSCD instance.
 
 ## SVELTE ACTIONS
 

--- a/packages/create-plugin/template/package.json
+++ b/packages/create-plugin/template/package.json
@@ -3,15 +3,13 @@
 	"private": true,
 	"version": "0.0.0",
 	"type": "module",
+	"source": "src/plugin.ts",
 	"scripts": {
 		"//====== DEV ======//": "",
 		"dev": "vite",
 		"//====== BUILD ======//": "",
 		"build": "vite build",
 		"build:watch": "vite build --watch",
-		"preview": "vite preview",
-		"//====== INTEGRATED ======//": "",
-		"integrated": "concurrently 'npm:build:watch' 'npm:preview'",
 		"//====== SVELTE ======//": "",
 		"check": "svelte-check --tsconfig ./tsconfig.json && tsc -p tsconfig.node.json"
 	},
@@ -31,15 +29,14 @@
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"@tsconfig/svelte": "^5.0.4",
 		"autoprefixer": "^10.4.20",
-		"concurrently": "^7.6.0",
 		"postcss": "^8.4.49",
-		"svelte": "^5.17.0",
-		"svelte-check": "^4.1.2",
+		"svelte": "^5.19.8",
+		"svelte-check": "^4.1.4",
 		"tailwindcss": "^3.4.15",
 		"tailwindcss-animate": "^1.0.7",
 		"tslib": "^2.8.0",
 		"typescript": "~5.6.2",
-		"vite": "^6.0.3",
-		"vite-plugin-dts": "^4.4.0"
+		"vite": "6.1.0",
+		"vite-plugin-dts": "^4.5.0"
 	}
 }

--- a/packages/create-plugin/template/src/plugin.svelte
+++ b/packages/create-plugin/template/src/plugin.svelte
@@ -12,13 +12,18 @@
 />
 
 <main 
+	id="plugin-container"
+	class="overflow-hidden"
 	use:initPlugin={{
 		getDoc: () => doc,
 		getDocName: () => docName,
 		getEditCount: () => editCount,
 		getIsCustomInstance: () => isCustomInstance,
-		host: $host(),
-		theme: 'legacy-oscd-instance'
+		getHost: () => $host() || window,
+		theme: 'legacy-oscd-instance',
+		definition: {
+			edition: 'ed2Rev1',
+		}
 	}}
 	data-plugin-name={jsonPackage.name}
 	data-plugin-version={jsonPackage.version}
@@ -29,14 +34,13 @@
 	</div>
 </main>
 
-
 <script lang="ts">
 // PACKAGE
 import jsonPackage from '../package.json'
 // CORE
-import { initPlugin, initSsdTemplate } from '@oscd-plugins/core-ui-svelte'
+import { initPlugin } from '@oscd-plugins/core-ui-svelte'
 // TYPES
-import type { Utils } from '@oscd-plugins/core-api/plugin/v1'
+import type { Plugin } from '@oscd-plugins/core-api/plugin/v1'
 
 // props
 const {
@@ -44,5 +48,5 @@ const {
 	docName,
 	editCount,
 	isCustomInstance
-}: Utils.PluginCustomComponentsProps = $props()
+}: Plugin.CustomComponentsProps = $props()
 </script>

--- a/packages/create-plugin/template/svelte.config.js
+++ b/packages/create-plugin/template/svelte.config.js
@@ -1,5 +1,6 @@
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	// Consult https://svelte.dev/docs#compile-time-svelte-preprocess
 	// for more information about preprocessors

--- a/packages/create-plugin/template/tsconfig.json
+++ b/packages/create-plugin/template/tsconfig.json
@@ -6,6 +6,7 @@
 		"useDefineForClassFields": true,
 		"module": "ESNext",
 		"resolveJsonModule": true,
+		"moduleResolution": "bundler",
 		/**
 		 * Typecheck JS in `.svelte` and `.js` files by default.
 		 * Disable checkJs if you'd like to use dynamic types in JS.
@@ -18,7 +19,8 @@
 		"moduleDetection": "force",
 		"paths": {
 			"@/*": ["src/*"]
-		}
+		},
+		"types": ["svelte", "vite/client"]
 	},
 	"include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
 	"references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/create-plugin/template/vite.config.ts
+++ b/packages/create-plugin/template/vite.config.ts
@@ -1,29 +1,32 @@
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { resolve } from 'node:path'
+import dts from 'vite-plugin-dts'
 
 const isDevelopment = process.env.NODE_ENV === 'development'
 
-// https://vite.dev/config/
 export default defineConfig({
-	plugins: [
-		svelte({
-			compilerOptions: {
-				customElement: true
-			}
-		})
-	],
+	plugins: [svelte(), dts({ rollupTypes: true })],
 	resolve: {
 		alias: {
 			'@': resolve(__dirname, 'src')
 		}
 	},
 	build: {
+		target: 'esnext',
 		lib: {
 			entry: resolve(__dirname, 'src/plugin.ts'),
 			formats: ['es'],
-			fileName: 'plugin'
+			fileName: 'index'
 		},
 		sourcemap: isDevelopment ? 'inline' : false
+	},
+	server: {
+		port: 4178,
+		cors: true
+	},
+	preview: {
+		port: 41781,
+		cors: true
 	}
 })

--- a/packages/plugins/communication-explorer2/.gitignore
+++ b/packages/plugins/communication-explorer2/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/packages/plugins/communication-explorer2/CHANGELOG.md
+++ b/packages/plugins/communication-explorer2/CHANGELOG.md
@@ -1,0 +1,159 @@
+# Changelog
+
+All notable changes to the communication explorer plugin will be documented here
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.35] - 2025-03-12
+### Fixed
+- fixing uilib examples
+
+## [0.0.34] - 2025-02-26
+### Changed
+- revert theme color fix (dark theme)
+
+## [0.0.33] - 2025-02-19
+### Added
+- Added option to remove grouping by bay. When selected, bays are visualized by small text labels instead. All IEDs that are part of a bay are selected when clicking a label.
+
+## [0.0.32] - 2025-02-13
+### Added
+- added outline around IEDs to visualize the bay containing them
+
+### Changed
+- IEDs are now grouped together by their bays
+
+## [0.0.31] - 2025-02-12
+### Added
+- bays (aswell as IEDs) can now be selected in the 'filter' searchbar on the right
+
+### Changed
+- filter dropdown + searchbar are now combined
+
+## [0.0.30] - 2023-11-14
+### Changed
+- accordion is now reacting to filtered service types
+
+### Fixed
+- align filter pills correctly
+- sampled values icon publish is missing
+- caching extracted information to improve performance
+
+## [0.0.29] - 2023-07-20
+### Fixed
+- align filter pills correctly
+- show sampled value icon
+
+### Added
+- add service type filter in accordion view
+
+## [0.0.28] - 2023-07-20
+### Fixed
+- show sampled values icon in sidebar
+
+## [0.0.26] - 2023-07-19
+
+### Changed
+- changed service-type icons
+
+### Added
+- add serviceType Label
+
+## [0.0.25] - 2023-06-23
+
+### Fixed
+- last content of the sidebar was not visible when scrollable
+
+## [0.0.24] - 2023-06-23
+
+### Added
+- draggable diagram when holding space bar
+- zoomable diagram with mouse wheel (not the best but works)
+
+### Changed
+
+- diagrams are centered
+
+### Fixed
+- MMS messages had the wrong direction
+- deselecting by clicking in empty areas worked only in the SVG
+  now it works in the whole panel
+- irrelevant connections were animated
+- selection were persisted even if the user opened a new file causing
+  an invalid state where everything was irrelevant
+- typo in the sidebar
+- removed misleading color of filter chips when clicked
+- empty section in sidebar
+- unnecessary scrollbar in sidebar
+
+### Added
+
+- groups have icons to show which type they are
+
+### Changed
+
+- long texts indicated with an ellipsis
+- adjusted paddings and margins
+
+### Fix
+
+- selecting a node did not trigger change detection
+
+
+## [0.0.22] - 2023-06-15
+
+## Added
+- clicking on the background of the diagram will deselect all elements
+- multiple IED selection
+- animated connections to see better the direction of messages
+- toggleable animation
+- MMS messages
+- preferences are persisted in local storage
+
+## Changed
+- new diagram design
+- sidebar has separate sections for focus mode and preferences
+
+## [0.0.12] - 2023-04-27
+
+### Fixed
+
+- Rename Labels in Sidebar Panel
+
+## [0.0.11] - 2023-04-26
+
+### Added
+
+- Experiment: hide irrelevant stuff
+- Experiment: search by IED name
+
+## [0.0.10] - 2023-04-26
+
+### Added
+
+- Added Sampled Value Messages to the Communication Explorer
+- Filter by message type
+
+### Fixed
+
+- fixed flickering of the view in case of any change
+
+## [0.0.9] - 2023-04-21
+
+### Fixed
+
+- Missing IED definition crashed the plugin.
+  It ignores the IED connection has a undefined IED.
+
+## [0.0.8] - 2023-04-20
+
+### Added
+
+- IEDs are selectable
+- Selecting an IED will show only relevant IEDs and connections
+- Filter for incoming and outgoing connections
+
+### Fixed
+
+- The SVG no grows with the diagram

--- a/packages/plugins/communication-explorer2/README.md
+++ b/packages/plugins/communication-explorer2/README.md
@@ -1,0 +1,3 @@
+# OSCD Plugin Template
+
+TODO

--- a/packages/plugins/communication-explorer2/index.html
+++ b/packages/plugins/communication-explorer2/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="h-screen">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenSCD Plugin</title>
+  </head>
+  <body class="h-full">
+    <div id="plugin" class="h-full"></div>
+    <script type="module" src="/src/plugin.dev.ts"></script>
+  </body>
+</html>

--- a/packages/plugins/communication-explorer2/package.json
+++ b/packages/plugins/communication-explorer2/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "@oscd-plugins/plugin-name",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"source": "src/plugin.ts",
+	"scripts": {
+		"//====== DEV ======//": "",
+		"dev": "vite",
+		"//====== BUILD ======//": "",
+		"build": "vite build",
+		"build:watch": "vite build --watch",
+		"//====== SVELTE ======//": "",
+		"check": "svelte-check --tsconfig ./tsconfig.json && tsc -p tsconfig.node.json"
+	},
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/plugin.d.ts",
+			"default": "./dist/plugin.js"
+		}
+	},
+	"devDependencies": {
+		"@oscd-plugins/core-api": "workspace:^",
+		"@oscd-plugins/core-standard": "workspace:^",
+		"@oscd-plugins/core-ui-svelte": "workspace:^",
+		"@sveltejs/vite-plugin-svelte": "^5.0.3",
+		"@tsconfig/svelte": "^5.0.4",
+		"autoprefixer": "^10.4.20",
+		"concurrently": "^7.6.0",
+		"postcss": "^8.4.49",
+		"svelte": "^5.19.8",
+		"svelte-check": "^4.1.4",
+		"tailwindcss": "^3.4.15",
+		"tailwindcss-animate": "^1.0.7",
+		"tslib": "^2.8.0",
+		"typescript": "~5.6.2",
+		"vite": "6.1.0",
+		"vite-plugin-dts": "^4.5.0"
+	},
+	"dependencies": {
+		"@xyflow/svelte": "^1.2.1",
+		"elkjs": "^0.10.0"
+	}
+}

--- a/packages/plugins/communication-explorer2/postcss.config.js
+++ b/packages/plugins/communication-explorer2/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {}
+	}
+}

--- a/packages/plugins/communication-explorer2/src/headless/services/index.ts
+++ b/packages/plugins/communication-explorer2/src/headless/services/index.ts
@@ -1,0 +1,1 @@
+export * as xmlService from './xml.service'

--- a/packages/plugins/communication-explorer2/src/headless/services/xml.service.ts
+++ b/packages/plugins/communication-explorer2/src/headless/services/xml.service.ts
@@ -1,0 +1,343 @@
+import { pluginGlobalStore } from "@oscd-plugins/core-ui-svelte";
+import { pluginLocalStore } from "../stores";
+// TYPES
+import type {
+	IEDElement,
+	CommunicationInfo,
+	IEDDetails,
+	PublishedMessage,
+	ReceivedMessage,
+	ExtRefElement,
+	ExtRefElementWithDatSet,
+	ReportControlInfo,
+	ReportControlElement,
+	ClientLNElement,
+	InputElement,
+	GSEControlElement
+} from './xml.types.d';
+
+// Constants
+const MESSAGE_TYPE = {
+	MMS: 'MMS',
+	GOOSE: 'GOOSE',
+	SMV: 'SMV'
+};
+
+// export default function xmlService(rootElement: () => Element, editCount: () => number) {
+const MMS_SERVICE_CB_NAME = 'MMS';
+const MMS_SERVICE_DAT_SET = 'not implemented yet';
+
+
+// Core XML query functions
+function searchElements<T>(selector: string, attributes: string[] = [], options: { root?: Element } = {}): T[] {
+	const root = options.root || pluginGlobalStore.editionStores[pluginLocalStore.currentEdition].rootElement
+	if (!root) return [];
+
+	const elements = Array.from(root.querySelectorAll(selector));
+
+	return elements.map(element => {
+		const result = { element } as unknown as Record<string, unknown>;
+
+		for (const attr of attributes) {
+			result[attr] = element.getAttribute(attr) || '';
+		}
+
+		return result as unknown as T;
+	});
+}
+
+// Implement IED methods
+function getIEDs(): IEDElement[] {
+	return searchElements<IEDElement>('IED', ['name']);
+}
+
+export function getBays(): Set<string> {
+	const root = pluginGlobalStore.editionStores[pluginLocalStore.currentEdition].rootElement
+	if (!root) return new Set<string>();
+
+	const bays = Array.from(root.querySelectorAll('Bay[name]')).map(bay =>
+		bay.getAttribute('name') || ''
+	);
+
+	return new Set(bays.filter(bay => bay !== ''));
+}
+
+function getBaysByIEDName(iedName: string): Set<string> {
+	const root = pluginGlobalStore.editionStores[pluginLocalStore.currentEdition].rootElement
+	if (!root) return new Set<string>();
+
+	// Find all LNodes referencing this IED
+	const lnodes = Array.from(root.querySelectorAll(`LNode[iedName="${iedName}"]`));
+
+	// Find the Bay ancestors of these LNodes
+	const bays = new Set<string>();
+	for (const lnode of lnodes) {
+		let parent = lnode.parentElement;
+		while (parent) {
+			if (parent.tagName === 'Bay' && parent.getAttribute('name')) {
+				bays.add(parent.getAttribute('name') || '');
+				break;
+			}
+			parent = parent.parentElement;
+		}
+	}
+
+	return bays;
+}
+
+// Parse details from an IED element
+function parseDetails(element: Element): IEDDetails {
+	const parser = new DOMParser();
+	const doc = parser.parseFromString(element.outerHTML, 'text/xml');
+
+	return {
+		logicalNodes: parseNodes(doc, ['LN', 'LN0']),
+		dataObjects: parseNodes(doc, ['DO', 'DOI']),
+		dataAttributes: parseNodes(doc, ['DA', 'FCDA'])
+	};
+}
+
+function parseNodes(doc: Document, nodeTypes: string[]): string[] {
+	const details: string[] = [];
+
+	for (const nodeType of nodeTypes) {
+		const elements = doc.getElementsByTagName(nodeType);
+		parseElements(elements, details);
+	}
+	return details;
+}
+
+function parseElements(elements: HTMLCollectionOf<Element>, details: string[]) {
+	for (const element of Array.from(elements)) {
+		details.push(parseAttributes(element));
+	}
+}
+
+function parseAttributes(element: Element): string {
+	let detail = `${element.localName} (`;
+
+	for (const attribute of Array.from(element.attributes)) {
+		detail += attribute.name;
+		if (attribute.value) {
+			detail += `=${attribute.value} `;
+		}
+	}
+	return `${detail})`;
+}
+
+// Find published messages
+function findPublishedMessages(ied: IEDElement): PublishedMessage[] {
+	const messages: PublishedMessage[] = [];
+	const reportControlInfos = findPublishedReportControls(ied);
+
+	for (const info of reportControlInfos) {
+		messages.push({
+			id: info.rptID,
+			name: info.name,
+			targetIEDName: info.clientIEDName,
+			serviceType: MESSAGE_TYPE.MMS,
+			serviceCbName: MMS_SERVICE_CB_NAME,
+			serviceDatSet: MMS_SERVICE_DAT_SET
+		});
+	}
+
+	return messages;
+}
+
+function findPublishedReportControls(ied: IEDElement): ReportControlInfo[] {
+	const controls: ReportControlInfo[] = [];
+	const reportControls = searchElements<ReportControlElement>('ReportControl', ['rptID', 'name', 'datSet'], { root: ied.element });
+
+	for (const reportControl of reportControls) {
+		const clientLNs = searchElements<ClientLNElement>('ClientLN', ['iedName'], { root: reportControl.element });
+
+		for (const clientLN of clientLNs) {
+			controls.push({
+				clientIEDName: clientLN.iedName,
+				rptID: reportControl.rptID,
+				name: reportControl.name
+			});
+		}
+	}
+
+	return controls;
+}
+
+// Find received messages
+function findReceivedMessages(ied: IEDElement, allIeds: IEDElement[]): ReceivedMessage[] {
+	const inputs = searchElements<InputElement>('Inputs', [], { root: ied.element });
+
+	const extRefs = inputs.flatMap(input =>
+		searchElements<ExtRefElement>('ExtRef', ['iedName', 'serviceType', 'srcCBName'], { root: input.element })
+	);
+
+	const extRefsWithConnectionID = extRefs.map(el => {
+		const srcCBName = el.srcCBName;
+		const iedName = el.iedName;
+		const parentIed = allIeds.find(i => i.name === iedName);
+
+		if (!parentIed) {
+			return {
+				...el,
+				datSet: null
+			};
+		}
+
+		const connection = searchElements<GSEControlElement>(
+			`GSEControl[name="${srcCBName}"]`,
+			['name', 'datSet'],
+			{ root: parentIed.element }
+		)[0];
+
+		return {
+			...el,
+			datSet: connection?.datSet || null
+		};
+	});
+
+	return groupInputExtRefElementsByIedNameServiceTypeAndSrcCBName(extRefsWithConnectionID);
+}
+
+function groupInputExtRefElementsByIedNameServiceTypeAndSrcCBName(
+	elements: ExtRefElementWithDatSet[]
+): ReceivedMessage[] {
+	const indexed: Record<string, {
+		elements: ExtRefElementWithDatSet[];
+		key: {
+			iedName: string;
+			serviceType: string;
+			srcCBName: string;
+			datSet: string | null;
+		};
+	}> = {};
+
+	for (const element of elements) {
+		if (element.iedName === '') {
+			continue;
+		}
+
+		const key = `${element.iedName}_${element.serviceType}_${element.srcCBName}_${element.datSet}`;
+		const tempKey = {
+			iedName: element.iedName,
+			serviceType: element.serviceType,
+			srcCBName: element.srcCBName,
+			datSet: element.datSet
+		};
+
+		if (!indexed[key]) {
+			indexed[key] = {
+				elements: [],
+				key: tempKey
+			};
+		}
+
+		indexed[key].elements.push(element);
+	}
+
+	const grouped: ReceivedMessage[] = [];
+
+	for (const obj of Object.values(indexed)) {
+		const { iedName, serviceType, srcCBName, datSet } = obj.key;
+
+		grouped.push({
+			iedName,
+			serviceType,
+			srcCBName,
+			datSet,
+			data: obj.elements
+		});
+	}
+
+	return grouped;
+}
+
+// Main method for getting communication information
+export function getIEDCommunicationInfos(): CommunicationInfo[] {
+	const ieds = getIEDs();
+	console.log('Found IEDs:', ieds);
+	const communicationInfos: CommunicationInfo[] = ieds.map(ied => {
+		return {
+			iedName: ied.name,
+			iedDetails: parseDetails(ied.element),
+			bays: getBaysByIEDName(ied.name),
+			published: findPublishedMessages(ied),
+			received: findReceivedMessages(ied, ieds)
+		};
+	});
+
+	return communicationInfos;
+}
+
+// Method to group communication info by bay
+function getIEDCommunicationInfosByBay(): Map<string, CommunicationInfo[]> {
+	const selector = 'SCL > Substation > VoltageLevel > Bay > LNode';
+	return getIEDCommunicationInfosByAncestor({
+		ancestor: 'Bay',
+		selector
+	});
+}
+
+// Method to group communication info by subnetwork
+function getIEDCommunicationInfosBySubNetworkBus(): Map<string, CommunicationInfo[]> {
+	const selector = 'SCL > Communication > SubNetwork > ConnectedAP';
+	return getIEDCommunicationInfosByAncestor({
+		ancestor: 'SubNetwork',
+		selector
+	});
+}
+
+function retrieveAncestorsNameBySelectorWithAttribute({
+	ancestor,
+	selector,
+	attribute
+}: {
+	ancestor: string;
+	selector: string;
+	attribute: string;
+}): string[] {
+	const root = pluginGlobalStore.editionStores[pluginLocalStore.currentEdition].rootElement
+	if (!root) return [];
+
+	const elements = Array.from(root.querySelectorAll(`${selector}[${attribute}]`));
+	const names = new Set<string>();
+
+	for (const element of elements) {
+		let parent = element.parentElement;
+		while (parent) {
+			if (parent.tagName === ancestor && parent.getAttribute('name')) {
+				names.add(parent.getAttribute('name') || '');
+				break;
+			}
+			parent = parent.parentElement;
+		}
+	}
+
+	return Array.from(names);
+}
+
+function getIEDCommunicationInfosByAncestor({
+	ancestor,
+	selector
+}: { ancestor: string; selector: string }): Map<string, CommunicationInfo[]> {
+	const ieds = getIEDCommunicationInfos();
+	const iedsCommunicationInfoByElement = new Map<string, CommunicationInfo[]>();
+
+	for (const ied of ieds) {
+		const names = retrieveAncestorsNameBySelectorWithAttribute({
+			ancestor,
+			selector,
+			attribute: `iedName='${ied.iedName}'`
+		});
+
+		for (const name of names) {
+			if (!iedsCommunicationInfoByElement.has(name)) {
+				iedsCommunicationInfoByElement.set(name, []);
+			}
+
+			const setList = iedsCommunicationInfoByElement.get(name);
+			if (setList) setList.push(ied);
+		}
+	}
+
+	return iedsCommunicationInfoByElement;
+}

--- a/packages/plugins/communication-explorer2/src/headless/services/xml.types.d.ts
+++ b/packages/plugins/communication-explorer2/src/headless/services/xml.types.d.ts
@@ -1,0 +1,74 @@
+export type IEDElement = {
+	name: string;
+	element: Element;
+}
+
+export type IEDDetails = {
+	logicalNodes: string[];
+	dataObjects: string[];
+	dataAttributes: string[];
+}
+
+export type ReportControlInfo = {
+	clientIEDName: string;
+	rptID: string;
+	name: string;
+}
+
+export type ReportControlElement = {
+	element: Element;
+	rptID: string;
+	name: string;
+	datSet: string;
+}
+
+export type ClientLNElement = {
+	element: Element;
+	iedName: string;
+}
+
+export type InputElement = {
+	element: Element;
+}
+
+export type GSEControlElement = {
+	element: Element;
+	name: string;
+	datSet: string;
+}
+
+export type PublishedMessage = {
+	id: string;
+	name: string;
+	targetIEDName: string;
+	serviceType: string;
+	serviceCbName: string;
+	serviceDatSet: string;
+}
+
+export type ExtRefElement = {
+	iedName: string;
+	serviceType: string;
+	srcCBName: string;
+	element: Element;
+}
+
+export type ExtRefElementWithDatSet = ExtRefElement & {
+	datSet: string | null;
+}
+
+export type ReceivedMessage = {
+	iedName: string;
+	serviceType: string;
+	srcCBName: string;
+	datSet: string | null;
+	data: ExtRefElementWithDatSet[];
+}
+
+export type CommunicationInfo = {
+	iedName: string;
+	iedDetails: IEDDetails;
+	bays: Set<string>;
+	published: PublishedMessage[];
+	received: ReceivedMessage[];
+}

--- a/packages/plugins/communication-explorer2/src/headless/stores/diagram.store.svelte.ts
+++ b/packages/plugins/communication-explorer2/src/headless/stores/diagram.store.svelte.ts
@@ -1,0 +1,23 @@
+// STORES
+import { pluginGlobalStore } from '@oscd-plugins/core-ui-svelte'
+// SERVICES
+import { xmlService } from '@/headless/services'
+
+class UseDiagramStore {
+	//====== CONSTANTS ======//
+
+	//====== STATES ======//
+	iedCommunicationInfos = $derived.by(() => {
+		if (`${pluginGlobalStore.editCount}`) return xmlService.getIEDCommunicationInfos();
+	});
+
+	bays = $derived.by(() => {
+		if (`${pluginGlobalStore.editCount}`) return xmlService.getBays();
+	});
+
+	//====== METHODS ======//
+
+
+}
+
+export const diagramStore = new UseDiagramStore()

--- a/packages/plugins/communication-explorer2/src/headless/stores/diagram/layout.helper.ts
+++ b/packages/plugins/communication-explorer2/src/headless/stores/diagram/layout.helper.ts
@@ -1,0 +1,285 @@
+import ELK from 'elkjs/lib/elk.bundled';
+import { Position } from '@xyflow/svelte';
+import type {
+	Node,
+	Edge
+} from '@xyflow/svelte';
+// STORES
+import { diagramStore } from '../diagram.store.svelte';
+// TYPES
+import type {
+	IEDNodeData,
+	ConnectionData,
+	CommunicationInfo
+} from './types';
+
+// Define a custom ElkFlowNode type that matches SvelteFlow Node type
+interface ElkFlowNode extends Node {
+	width?: number;
+	height?: number;
+	parent?: string;
+}
+
+interface LayoutConfig {
+	iedWidth: number;
+	iedHeight: number;
+	bayLabelHeight: number;
+	bayLabelGap: number;
+	spacingBetweenNodes?: number;
+	spacingBase?: number;
+}
+
+interface LayoutPreferences {
+	playConnectionAnimation: boolean;
+	showConnectionArrows: boolean;
+	groupByBay: boolean;
+	isFocusModeOn: boolean;
+}
+
+interface LayoutFilter {
+	nameFilter: string;
+	selectedTypes: Set<string>;
+}
+
+const defaultConfig: LayoutConfig = {
+	iedWidth: 150,
+	iedHeight: 40,
+	bayLabelHeight: 15,
+	bayLabelGap: 2,
+	spacingBetweenNodes: 100,
+	spacingBase: 40
+};
+
+const defaultPreferences: LayoutPreferences = {
+	playConnectionAnimation: true,
+	showConnectionArrows: true,
+	groupByBay: true,
+	isFocusModeOn: false
+};
+
+const defaultFilter: LayoutFilter = {
+	nameFilter: '',
+	selectedTypes: new Set()
+};
+
+/**
+ * Generates SvelteFlow nodes and edges from IED communication info
+ */
+export async function generateDiagramLayout(
+	iedInfos: CommunicationInfo[] = [],
+	config: Partial<LayoutConfig> = {},
+	preferences: Partial<LayoutPreferences> = {},
+	filter: Partial<LayoutFilter> = {}
+): Promise<{ nodes: Node[], edges: Edge[] }> {
+	// Merge defaults with provided options
+	const layoutConfig: LayoutConfig = { ...defaultConfig, ...config };
+	const layoutPreferences: LayoutPreferences = { ...defaultPreferences, ...preferences };
+	const layoutFilter: LayoutFilter = { ...defaultFilter, ...filter };
+
+	// Get IED communication info and bays
+	// const iedInfos = diagramStore.iedCommunicationInfos || [];
+	// console.log(iedInfos);
+	const allBays = diagramStore.bays;
+	console.log(allBays);
+
+	// Convert IED info to nodes and connections to edges
+	const { nodes, edges } = generateNodesAndEdges(
+		iedInfos,
+		layoutConfig,
+		layoutPreferences,
+		layoutFilter
+	);
+
+	return { nodes, edges };
+
+	// Apply ELK layout to the nodes and edges
+	// return await applyElkLayout(nodes, edges, layoutConfig, layoutPreferences);
+}
+
+/**
+ * Converts IED communication info to SvelteFlow nodes and edges
+ */
+function generateNodesAndEdges(
+	iedInfos: CommunicationInfo[],
+	config: LayoutConfig,
+	preferences: LayoutPreferences,
+	_filter: LayoutFilter
+): { nodes: ElkFlowNode[], edges: Edge[] } {
+	const nodes: ElkFlowNode[] = [];
+	const edges: Edge[] = [];
+	const iedMap = new Map<string, ElkFlowNode>();
+
+	// Process IEDs and create nodes
+	for (const ied of iedInfos) {
+		// Create IED node
+		const iedNode: ElkFlowNode = {
+			id: `ied-${ied.iedName}`,
+			type: 'iedNode', // Custom node type for rendering
+			position: { x: 0, y: 0 }, // Initial position, will be updated by ELK
+			data: {
+				iedName: ied.iedName,
+				bays: ied.bays,
+				isRelevant: true,
+				details: ied.iedDetails
+			} as IEDNodeData,
+			width: config.iedWidth,
+			height: config.iedHeight
+		};
+
+		iedMap.set(ied.iedName, iedNode);
+		nodes.push(iedNode);
+
+		// Process connections (published and received messages)
+		processConnections(ied, edges, preferences);
+	}
+
+	return { nodes, edges };
+}
+
+/**
+ * Process IED connections to create edges
+ */
+function processConnections(
+	ied: CommunicationInfo,
+	edges: Edge[],
+	preferences: LayoutPreferences
+) {
+	// Process published messages
+	for (const message of ied.published) {
+		if (!message.targetIEDName) continue;
+
+		edges.push({
+			id: `edge-${ied.iedName}-${message.targetIEDName}-${message.id}`,
+			source: `ied-${ied.iedName}`,
+			target: `ied-${message.targetIEDName}`,
+			type: 'customEdge',
+			animated: preferences.playConnectionAnimation,
+			data: {
+				sourceIEDName: ied.iedName,
+				targetIEDName: message.targetIEDName,
+				serviceType: message.serviceType,
+				serviceCbName: message.serviceCbName,
+				datSet: message.serviceDatSet,
+				showLabel: true,
+				isRelevant: true,
+				animated: preferences.playConnectionAnimation
+			} as ConnectionData
+		});
+	}
+
+	// Process received messages
+	for (const message of ied.received) {
+		if (!message.iedName) continue;
+
+		edges.push({
+			id: `edge-${message.iedName}-${ied.iedName}-${message.srcCBName}`,
+			source: `ied-${message.iedName}`,
+			target: `ied-${ied.iedName}`,
+			type: 'customEdge',
+			animated: preferences.playConnectionAnimation,
+			data: {
+				sourceIEDName: message.iedName,
+				targetIEDName: ied.iedName,
+				serviceType: message.serviceType,
+				serviceCbName: message.srcCBName,
+				datSet: message.datSet,
+				showLabel: true,
+				isRelevant: true,
+				animated: preferences.playConnectionAnimation
+			} as ConnectionData
+		});
+	}
+}
+
+/**
+ * Apply ELK layout to nodes and edges
+ */
+// async function applyElkLayout(
+// 	nodes: ElkFlowNode[],
+// 	edges: Edge[],
+// 	config: LayoutConfig,
+// 	preferences: LayoutPreferences
+// ): Promise<{ nodes: Node[], edges: Edge[] }> {
+// 	const elk = new ELK();
+
+// 	const elkOptions = {
+// 		'elk.algorithm': 'org.eclipse.elk.layered',
+// 		'org.eclipse.elk.layered.unnecessaryBendpoints': 'true',
+// 		'org.eclipse.elk.layered.nodePlacement.bk.fixedAlignment': 'RIGHTUP',
+// 		'elk.direction': 'LEFT',
+// 		'elk.hierarchyHandling': preferences.groupByBay ? 'INCLUDE_CHILDREN' : 'SEPARATE_CHILDREN',
+// 		'org.eclipse.elk.layered.spacing.baseValue': String(config.spacingBase || 40),
+// 		'org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers': String(config.spacingBetweenNodes || 100),
+// 	};
+
+// 	const isHorizontal = elkOptions['elk.direction'] === 'RIGHT';
+
+// 	// Convert nodes and edges to ELK format
+// 	// Define a minimal interface for the ELK graph structure
+// 	interface ElkGraphLayout {
+// 		id: string;
+// 		layoutOptions: Record<string, string>;
+// 		children: Array<{
+// 			id: string;
+// 			width?: number;
+// 			height?: number;
+// 			targetPosition?: Position;
+// 			sourcePosition?: Position;
+// 			parent?: string;
+// 		}>;
+// 		edges: Array<{
+// 			id: string;
+// 			sources: string[];
+// 			targets: string[];
+// 		}>;
+// 	}
+
+// 	// Create the ELK graph structure
+// 	const elkGraph: ElkGraphLayout = {
+// 		id: 'root',
+// 		layoutOptions: elkOptions,
+// 		children: nodes.map(node => ({
+// 			id: node.id,
+// 			width: node.width,
+// 			height: node.height,
+// 			targetPosition: isHorizontal ? Position.Left : Position.Top,
+// 			sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
+// 			parent: node.parent
+// 		})),
+// 		edges: edges.map(edge => ({
+// 			id: edge.id,
+// 			sources: [edge.source],
+// 			targets: [edge.target]
+// 		}))
+// 	};
+
+// 	try {
+// 		// Perform the layout calculation
+// 		const layout = await elk.layout(elkGraph);
+
+// 		// Map the layout back to SvelteFlow nodes
+// 		const flowNodes = layout.children?.map(elkNode => {
+// 			const original = nodes.find(n => n.id === elkNode.id);
+// 			if (!original || !elkNode.x || !elkNode.y) return original;
+
+// 			const flowNode: Node = {
+// 				...original,
+// 				position: {
+// 					x: elkNode.x,
+// 					y: elkNode.y
+// 				}
+// 			};
+
+// 			return flowNode;
+// 		}).filter((node): node is Node => node !== undefined) || [];
+
+// 		return { nodes: flowNodes, edges };
+// 	} catch (error) {
+// 		console.error('Error applying ELK layout:', error);
+// 		// Return original nodes and edges in case of error
+// 		return {
+// 			nodes: nodes as Node[],
+// 			edges
+// 		};
+// 	}
+// }

--- a/packages/plugins/communication-explorer2/src/headless/stores/diagram/types.ts
+++ b/packages/plugins/communication-explorer2/src/headless/stores/diagram/types.ts
@@ -1,0 +1,98 @@
+// Node data types used in SvelteFlow components
+
+/**
+ * IED Node data interface
+ */
+export interface IEDNodeData extends Record<string, unknown> {
+	iedName: string;
+	bays: Set<string>;
+	isRelevant: boolean;
+	details?: {
+		logicalNodes: string[];
+		dataObjects: string[];
+		dataAttributes: string[];
+	};
+}
+
+/**
+ * Bay Node data interface
+ */
+export interface BayNodeData extends Record<string, unknown> {
+	bayName: string;
+	isRelevant: boolean;
+	isBayNode: true;
+}
+
+/**
+ * Connection data interface
+ */
+export interface ConnectionData extends Record<string, unknown> {
+	sourceIEDName: string;
+	targetIEDName: string;
+	serviceType: string;
+	serviceCbName: string;
+	datSet: string | null;
+	isRelevant?: boolean;
+	showLabel?: boolean;
+	animated?: boolean;
+}
+
+/**
+ * Published message information
+ */
+export interface PublishedMessage {
+	id: string;
+	name: string;
+	targetIEDName: string;
+	serviceType: string;
+	serviceCbName: string;
+	serviceDatSet: string;
+}
+
+/**
+ * Received message information
+ */
+export interface ReceivedMessage {
+	iedName: string;
+	serviceType: string;
+	srcCBName: string;
+	datSet: string | null;
+	data: unknown[];
+}
+
+/**
+ * IED details information
+ */
+export interface IEDDetails {
+	logicalNodes: string[];
+	dataObjects: string[];
+	dataAttributes: string[];
+}
+
+/**
+ * Complete communication information for an IED
+ */
+export interface CommunicationInfo {
+	iedName: string;
+	iedDetails: IEDDetails;
+	bays: Set<string>;
+	published: PublishedMessage[];
+	received: ReceivedMessage[];
+}
+
+/**
+ * Custom Node type for SvelteFlow + ELK integration
+ */
+export interface ElkFlowNode extends Node {
+	id: string;
+	position: { x: number; y: number };
+	data: Record<string, unknown>;
+	type?: string;
+	width?: number;
+	height?: number;
+	x?: number;
+	y?: number;
+	parentId?: string;
+	extent?: string;
+	children?: ElkFlowNode[];
+}

--- a/packages/plugins/communication-explorer2/src/headless/stores/index.ts
+++ b/packages/plugins/communication-explorer2/src/headless/stores/index.ts
@@ -1,0 +1,3 @@
+export * from './plugin-local.svelte'
+export * from './sidebar.svelte'
+export * from './diagram.store.svelte'

--- a/packages/plugins/communication-explorer2/src/headless/stores/plugin-local.svelte.ts
+++ b/packages/plugins/communication-explorer2/src/headless/stores/plugin-local.svelte.ts
@@ -1,0 +1,88 @@
+// CORE
+import {
+	getCurrentDefinition,
+	findAllStandardElementsBySelector
+} from '@oscd-plugins/core-api/plugin/v1'
+import { pluginGlobalStore, ssdStore } from '@oscd-plugins/core-ui-svelte'
+// TYPES
+import type { IEC61850 } from '@oscd-plugins/core-standard'
+
+class UsePluginLocalStore {
+	//====== CONSTANTS ======//
+
+	isUsingIndexedDB = $state(false)
+	// CHANGE THESE VALUES TO MATCH YOUR PLUGIN
+	currentEdition: IEC61850.AvailableEdition = 'ed2Rev1' as const
+	currentUnstableRevision: IEC61850.AvailableUnstableRevision<
+		typeof this.currentEdition
+	> = 'IEC61850-90-30' as const
+
+	pluginNamespacePrefix = 'type-designer' as const
+	pluginNamespaceUri = 'https://transnetbw.de/type-designer' as const
+
+	//====== STATES ======//
+
+	namespaces = $derived({
+		currentPlugin: {
+			uri: this.pluginNamespaceUri,
+			prefix: this.pluginNamespacePrefix
+		},
+		currentUnstableRevision: {
+			uri: pluginGlobalStore.revisionsStores[this.currentUnstableRevision]
+				.currentNamespaceUri,
+			prefix: pluginGlobalStore.revisionsStores[
+				this.currentUnstableRevision
+			].currentNamespacePrefix
+		}
+	})
+
+	currentDefinition = $derived(
+		getCurrentDefinition({
+			currentEdition: this.currentEdition,
+			currentUnstableRevision: this.currentUnstableRevision
+		}) as IEC61850.CurrentDefinition<
+			typeof this.currentEdition,
+			typeof this.currentUnstableRevision
+		>
+	)
+
+	rootElement = $derived(
+		pluginGlobalStore.revisionsStores[this.currentUnstableRevision]
+			.rootElement
+	)
+
+	rootSubElements = $derived({
+		...pluginGlobalStore.editionStores[this.currentEdition].rootSubElements,
+		...pluginGlobalStore.revisionsStores[this.currentUnstableRevision]
+			.rootSubElements
+	})
+
+	//====== METHODS ======//
+
+	updateSCLVersion() {
+		if (pluginGlobalStore.currentVersion === '2007C5') return
+		if (this.rootElement)
+			pluginGlobalStore.updateSCLVersion({
+				rootElement: this.rootElement,
+				version: '2007',
+				revision: 'C',
+				release: '5'
+			})
+	}
+
+	addUnstableNamespaceToRootElement() {
+		if (
+			pluginGlobalStore.revisionsStores[this.currentUnstableRevision]
+				.hasUnstableNamespace
+		)
+			return
+
+		if (this.rootElement)
+			pluginGlobalStore.addNamespaceToRootElement({
+				rootElement: this.rootElement,
+				namespace: this.namespaces.currentUnstableRevision
+			})
+	}
+}
+
+export const pluginLocalStore = new UsePluginLocalStore()

--- a/packages/plugins/communication-explorer2/src/headless/stores/sidebar.svelte.ts
+++ b/packages/plugins/communication-explorer2/src/headless/stores/sidebar.svelte.ts
@@ -1,0 +1,8 @@
+
+
+class UseSidebarStore {
+	//====== STATES ======//
+
+}
+
+export const sidebarStore = new UseSidebarStore()

--- a/packages/plugins/communication-explorer2/src/plugin.dev.ts
+++ b/packages/plugins/communication-explorer2/src/plugin.dev.ts
@@ -1,0 +1,15 @@
+import { mount } from 'svelte'
+import Plugin from './plugin.svelte'
+import { sclMockA } from '@oscd-plugins/core-api/mocks/v1'
+import '@xyflow/svelte/dist/style.css'
+
+mount(Plugin, {
+	target: document.getElementById('plugin') as Element,
+	props: {
+		doc: new DOMParser().parseFromString(sclMockA, 'text/xml'),
+		docName: 'scl-mock-A',
+		editCount: 0,
+		locale: 'en',
+		isCustomInstance: false
+	}
+})

--- a/packages/plugins/communication-explorer2/src/plugin.svelte
+++ b/packages/plugins/communication-explorer2/src/plugin.svelte
@@ -1,0 +1,82 @@
+<svelte:options 
+	customElement={{
+		props: {
+			doc: { reflect: true, type: 'Object'},
+			docName: { reflect: true, type: 'String'},
+			editCount: { reflect: true, type: 'Number'},
+			locale: { reflect: true, type: 'String'},
+			pluginType: { reflect: true, type: 'String'},
+			isCustomInstance: { reflect: true, type: 'Boolean'},
+		}
+	}}
+/>
+
+<main 
+	id="plugin-container"
+	class="overflow-hidden"
+	use:initPlugin={{
+		getDoc: () => doc,
+		getDocName: () => docName,
+		getEditCount: () => editCount,
+		getIsCustomInstance: () => isCustomInstance,
+		getHost: () => $host() || window,
+		theme: 'legacy-oscd-instance',
+		useSvelteFlowTheme: true,
+		definition: {
+			edition: 'ed2Rev1',
+		}
+	}}
+	data-plugin-name={jsonPackage.name}
+	data-plugin-version={jsonPackage.version}
+>
+	<Sidebar.Provider
+		open={false}
+		class=" h-[--plugin-container-height] min-h-full"
+		style="--sidebar-width: 20rem; --sidebar-width-mobile: 20rem;"
+	>
+		<div class="flex flex-col w-full h-[--plugin-container-height] min-h-full">
+			<Diagram />
+		</div>
+		<SidebarWrapper />
+	</Sidebar.Provider>
+</main>
+
+
+<script lang="ts">
+// PACKAGE
+import jsonPackage from '../package.json'
+// CORE
+import { initPlugin, Sidebar } from '@oscd-plugins/core-ui-svelte'
+// COMPONENTS
+import SidebarWrapper from '@/ui/components/sidebar/sidebar-wrapper.svelte'
+import Diagram from '@/ui/components/diagram/diagram.svelte'
+// TYPES
+import type { Plugin } from '@oscd-plugins/core-api/plugin/v1'
+// SERVICES
+
+// import { initXmlService } from './headless/services/diagram.service'
+
+// props
+const {
+	doc,
+	docName,
+	editCount,
+	isCustomInstance
+}: Plugin.CustomComponentsProps = $props()
+// let trigger = $state(0)
+
+// onMount(() => {
+// 	pluginLocalStore.isUsingIndexedDB = isUsingIndexedDB
+
+// 	// Initialize XML service
+// 	const xmlServiceInstance = initXmlService(
+// 		() => doc.documentElement,
+// 		() => editCount
+// 	)
+
+// 	// Subscribe to document updates
+// 	// xmlServiceInstance.subscribeToUpdate((editCountValue) => {
+// 	// 	trigger = editCountValue
+// 	// })
+// })
+</script>

--- a/packages/plugins/communication-explorer2/src/plugin.ts
+++ b/packages/plugins/communication-explorer2/src/plugin.ts
@@ -1,0 +1,4 @@
+import Plugin from './plugin.svelte'
+import type { Component } from 'svelte'
+import '@xyflow/svelte/dist/style.css'
+export default (Plugin as Component).element

--- a/packages/plugins/communication-explorer2/src/ui/components/diagram/diagram.svelte
+++ b/packages/plugins/communication-explorer2/src/ui/components/diagram/diagram.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+import { onMount } from 'svelte'
+import { SvelteFlowProvider, SvelteFlow, useSvelteFlow } from '@xyflow/svelte'
+import '@xyflow/svelte/dist/style.css'
+
+import IEDNode from './nodes/ied-node.svelte'
+// STORES
+import { diagramStore } from '@/headless/stores'
+import { generateDiagramLayout } from '@/headless/stores/diagram/layout.helper'
+// TYPES
+import type { Node, Edge } from '@xyflow/svelte'
+
+// State for nodes and edges
+let nodes = $state.raw<Node[]>([])
+let edges = $state.raw<Edge[]>([])
+let isLoading = $state(true)
+
+// Define node and edge types
+const nodeTypes = {
+	iedNode: IEDNode
+}
+
+// Load diagram data
+async function loadDiagramData() {
+	isLoading = true
+	const layout = await generateDiagramLayout(
+		diagramStore.iedCommunicationInfos,
+		{} // Default layout config
+	)
+	console.log(layout)
+
+	// Update state in a way that ensures reactivity
+	nodes = [...layout.nodes]
+	edges = [...layout.edges]
+
+	// Give the diagram time to render before removing the loading overlay
+	setTimeout(() => {
+		isLoading = false
+	}, 100)
+}
+
+$inspect('found IEDS', diagramStore.iedCommunicationInfos)
+$inspect('found bays', diagramStore.bays)
+$inspect('edges', edges)
+$inspect('nodes', nodes)
+
+// Initialize the diagram on component mount
+onMount(async () => {
+	await loadDiagramData()
+})
+</script>
+
+<div class="diagram-container" style="height: 100%; width: 100%;">
+  {#if isLoading}
+    <div class="loading-overlay">
+      <span>Loading diagram...</span>
+    </div>
+  {/if}
+  
+  <SvelteFlowProvider>
+    <SvelteFlow
+      nodes={nodes}
+      edges={edges}
+      fitView
+      {nodeTypes}
+      defaultEdgeOptions={{ 
+        type: 'customEdge',
+        animated: true
+      }}
+    >
+    </SvelteFlow>
+  </SvelteFlowProvider>
+</div>
+
+<style>
+  .loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(255, 255, 255, 0.7);
+    z-index: 10;
+  }
+</style>
+
+
+
+

--- a/packages/plugins/communication-explorer2/src/ui/components/diagram/nodes/ied-node.svelte
+++ b/packages/plugins/communication-explorer2/src/ui/components/diagram/nodes/ied-node.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+import { type NodeProps, Handle, Position } from '@xyflow/svelte'
+import type { IEDNodeData } from '@/headless/stores/diagram/types'
+
+// Extract node properties using Svelte 5 props rune
+const { id, data, selected } = $props<{
+	id: NodeProps['id']
+	data: NodeProps['data']
+	selected: NodeProps['selected']
+}>()
+
+// Cast data to our expected type using runes
+const iedData = $derived(data as IEDNodeData)
+const isRelevant = $derived(iedData.isRelevant !== false)
+const opacity = $derived(isRelevant ? '1' : '0.5')
+const bayList = $derived(
+	iedData.bays ? Array.from(iedData.bays).join(', ') : ''
+)
+const showBayInfo = $derived(!!bayList)
+</script>
+
+<div 
+  class="ied-node {selected ? 'selected' : ''}" 
+  style="opacity: {opacity};"
+>
+  <!-- Left side handles for inputs -->
+  <Handle 
+    type="target"
+    position={Position.Left}
+    style="width: 8px; height: 8px; top: 50%;"
+  />
+  
+  <div class="ied-content">
+    <div class="ied-name" title={iedData.iedName}>
+      {iedData.iedName}
+    </div>
+    
+    {#if showBayInfo}
+      <div class="ied-bay" title="Bay: {bayList}">
+        <span class="bay-icon">⚡</span> {bayList}
+      </div>
+    {/if}
+  </div>
+  
+  <!-- Right side handles for outputs -->
+  <Handle 
+    type="source"
+    position={Position.Right}
+    style="width: 8px; height: 8px; top: 50%;"
+  />
+</div>
+
+<style>
+  .ied-node {
+    padding: 10px;
+    border-radius: 4px;
+    background: white;
+    border: 1px solid #ccc;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    font-size: 12px;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    transition: all 0.2s ease;
+  }
+  
+  .ied-node.selected {
+    border: 2px solid #3498db;
+    box-shadow: 0 0 8px rgba(52, 152, 219, 0.5);
+  }
+  
+  .ied-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1;
+  }
+  
+  .ied-name {
+    font-weight: bold;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  
+  .ied-bay {
+    font-size: 10px;
+    color: #777;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 4px;
+  }
+  
+  .bay-icon {
+    font-size: 8px;
+  }
+</style>

--- a/packages/plugins/communication-explorer2/src/ui/components/sidebar/sidebar-wrapper.svelte
+++ b/packages/plugins/communication-explorer2/src/ui/components/sidebar/sidebar-wrapper.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+// COMPONENTS
+import { Sidebar } from '@oscd-plugins/core-ui-svelte'
+</script>
+
+<Sidebar.Root side="right" class="sidebar-root z-0" collapsible="none" >
+
+	<Sidebar.Header class="text-xl font-black">Sidebar header</Sidebar.Header>
+	<Sidebar.Content class="p-4 space-y-5">
+		
+		<p>Sidebar content updated</p>
+	</Sidebar.Content>
+	<Sidebar.Footer> <p>Sidebar footer</p></Sidebar.Footer>
+
+</Sidebar.Root>
+
+

--- a/packages/plugins/communication-explorer2/svelte.config.js
+++ b/packages/plugins/communication-explorer2/svelte.config.js
@@ -1,0 +1,11 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+/** @type {import('@sveltejs/kit').Config} */
+export default {
+	// Consult https://svelte.dev/docs#compile-time-svelte-preprocess
+	// for more information about preprocessors
+	preprocess: vitePreprocess(),
+	compilerOptions: {
+		customElement: true
+	}
+}

--- a/packages/plugins/communication-explorer2/tailwind.config.ts
+++ b/packages/plugins/communication-explorer2/tailwind.config.ts
@@ -1,0 +1,7 @@
+import TailwindPreset from '@oscd-plugins/core-ui-svelte/preset'
+// TYPES
+import type { Config } from 'tailwindcss'
+
+export default {
+	presets: [TailwindPreset]
+} satisfies Omit<Config, 'content'>

--- a/packages/plugins/communication-explorer2/tsconfig.json
+++ b/packages/plugins/communication-explorer2/tsconfig.json
@@ -1,0 +1,27 @@
+{
+	"extends": "@tsconfig/svelte/tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": ".",
+		"target": "ESNext",
+		"useDefineForClassFields": true,
+		"module": "ESNext",
+		"resolveJsonModule": true,
+		"moduleResolution": "bundler",
+		/**
+		 * Typecheck JS in `.svelte` and `.js` files by default.
+		 * Disable checkJs if you'd like to use dynamic types in JS.
+		 * Note that setting allowJs false does not prevent the use
+		 * of JS in `.svelte` files.
+		 */
+		"allowJs": true,
+		"checkJs": true,
+		"isolatedModules": true,
+		"moduleDetection": "force",
+		"paths": {
+			"@/*": ["src/*"]
+		},
+		"types": ["svelte", "vite/client"]
+	},
+	"include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+	"references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/packages/plugins/communication-explorer2/tsconfig.node.json
+++ b/packages/plugins/communication-explorer2/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/plugins/communication-explorer2/vite.config.ts
+++ b/packages/plugins/communication-explorer2/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { resolve } from 'node:path'
+import dts from 'vite-plugin-dts'
+
+const isDevelopment = process.env.NODE_ENV === 'development'
+
+export default defineConfig({
+	plugins: [svelte(), dts({ rollupTypes: true })],
+	resolve: {
+		alias: {
+			'@': resolve(__dirname, 'src')
+		}
+	},
+	build: {
+		target: 'esnext',
+		lib: {
+			entry: resolve(__dirname, 'src/plugin.ts'),
+			formats: ['es'],
+			fileName: 'index'
+		},
+		sourcemap: isDevelopment ? 'inline' : false
+	},
+	server: {
+		port: 4178,
+		cors: true
+	},
+	preview: {
+		port: 41781,
+		cors: true
+	}
+})

--- a/packages/uilib/src/lib/plugins/communication-explorer/_func-layout-calculation/node-layout.ts
+++ b/packages/uilib/src/lib/plugins/communication-explorer/_func-layout-calculation/node-layout.ts
@@ -59,7 +59,7 @@ export async function calculateLayout(
 	const graph: ElkNode = {
 		id: 'graph-root',
 		layoutOptions: {
-			'elk.algorithm': 'org.eclipse.elk.layered',			
+			'elk.algorithm': 'org.eclipse.elk.layered',
 			'org.eclipse.elk.layered.unnecessaryBendpoints': 'true',
 			'org.eclipse.elk.layered.nodePlacement.bk.fixedAlignment':
 				'RIGHTUP',
@@ -87,7 +87,8 @@ export async function calculateLayout(
 		children,
 		edges
 	}
-
+	console.log('edges', edges)
+	console.log('children', children)
 	// message type information gets lost here
 	const root = (await elk.layout(graph)) as RootNode
 
@@ -120,14 +121,14 @@ export async function calculateLayout(
 										}
 									}
 								}
-							}						
+							}
 						}
 					}
 				}
 			}
 
 			for (const child of node.children) {
-				
+
 				//ELK only gives us local positions for child IEDs (I couldn't find a way to change that...)
 				//as a workaround we add the bay's position to all it's child IEDs
 				if (node.x !== undefined && node.y !== undefined) {
@@ -166,13 +167,13 @@ function generateBayLayout(ieds: IEDNode[], edges: IEDConnectionWithCustomValues
 		else {
 			const spacing = config.spacingBase ?? 20
 			bayNode = {
-				id:         	`bay-${id++}`, //placeholder
-				width:      	config.iedWidth,
-				height:     	config.iedHeight,
-				label:      	bayLabel,
-				isRelevant: 	ied.isRelevant,
-				isBayNode:		true,
-				children:   	[ied], //IEDs must be children of their bays, otherwise ELK won't calculate proper layouts!
+				id: `bay-${id++}`, //placeholder
+				width: config.iedWidth,
+				height: config.iedHeight,
+				label: bayLabel,
+				isRelevant: ied.isRelevant,
+				isBayNode: true,
+				children: [ied], //IEDs must be children of their bays, otherwise ELK won't calculate proper layouts!
 				layoutOptions: {
 					'elk.padding': `[top=${spacing * 2},left=${spacing},right=${spacing},bottom=${spacing}]` //double top spacing to account for baycontainer label!
 				},

--- a/packages/uilib/src/lib/plugins/communication-explorer/telemetry-view/telemetry-view.svelte
+++ b/packages/uilib/src/lib/plugins/communication-explorer/telemetry-view/telemetry-view.svelte
@@ -49,8 +49,10 @@ async function initInfos(
 
 	if (root !== lastUsedRoot) {
 		const iedInfos = getIEDCommunicationInfos(root)
+		console.log(iedInfos)
 		lastExtractedInfos = iedInfos
 		lastExtractedBays = getBays(root)
+		console.log(lastExtractedBays)
 		lastUsedRoot = root
 	}
 	rootNode = await calculateLayout(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,10 @@ importers:
         version: 5.6.3
 
   packages/core/ui-svelte:
+    dependencies:
+      '@xyflow/svelte':
+        specifier: ^1.2.1
+        version: 1.2.1(svelte@5.20.1)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^3.2.2
@@ -346,6 +350,64 @@ importers:
       vite-plugin-css-injected-by-js:
         specifier: ^3.1.1
         version: 3.5.2(vite@4.5.5(@types/node@22.10.1)(sass@1.82.0))
+
+  packages/plugins/communication-explorer2:
+    dependencies:
+      '@xyflow/svelte':
+        specifier: ^1.2.1
+        version: 1.2.1(svelte@5.20.1)
+      elkjs:
+        specifier: ^0.10.0
+        version: 0.10.0
+    devDependencies:
+      '@oscd-plugins/core-api':
+        specifier: workspace:^
+        version: link:../../core/api
+      '@oscd-plugins/core-standard':
+        specifier: workspace:^
+        version: link:../../core/standard
+      '@oscd-plugins/core-ui-svelte':
+        specifier: workspace:^
+        version: link:../../core/ui-svelte
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.3
+        version: 5.0.3(svelte@5.20.1)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0))
+      '@tsconfig/svelte':
+        specifier: ^5.0.4
+        version: 5.0.4
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.4.20(postcss@8.5.2)
+      concurrently:
+        specifier: ^7.6.0
+        version: 7.6.0
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.2
+      svelte:
+        specifier: ^5.19.8
+        version: 5.20.1
+      svelte-check:
+        specifier: ^4.1.4
+        version: 4.1.4(picomatch@4.0.2)(svelte@5.20.1)(typescript@5.6.3)
+      tailwindcss:
+        specifier: ^3.4.15
+        version: 3.4.17
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.17)
+      tslib:
+        specifier: ^2.8.0
+        version: 2.8.1
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.3
+      vite:
+        specifier: 6.1.0
+        version: 6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0)
+      vite-plugin-dts:
+        specifier: ^4.5.0
+        version: 4.5.0(@types/node@22.10.1)(rollup@4.34.8)(typescript@5.6.3)(vite@6.1.0(@types/node@22.10.1)(jiti@1.21.7)(sass@1.82.0)(yaml@2.7.0))
 
   packages/plugins/diffing-tool:
     dependencies:
@@ -2755,6 +2817,11 @@ packages:
     peerDependencies:
       svelte: ^3.55.0 || ^4.0.0 || ^5.0.0
 
+  '@svelte-put/shortcut@4.1.0':
+    resolution: {integrity: sha512-wImNEIkbxAIWFqlfuhcbC+jRPDeRa/uJGIXHMEVVD+jqL9xCwWNnkGQJ6Qb2XVszuRLHlb8SGZDL3Io/h3vs8w==}
+    peerDependencies:
+      svelte: ^5.1.0
+
   '@sveltejs/adapter-auto@1.0.3':
     resolution: {integrity: sha512-hc7O12YQqvZ1CD4fo1gMJuPzBZvuoG5kwxb2RRoz4fVoB8B2vuPO2cY751Ln0G6T/HMrAf8kCqw6Pg+wbxcstw==}
     peerDependencies:
@@ -3468,8 +3535,16 @@ packages:
     peerDependencies:
       svelte: ^3.0.0 || ^4.0.0
 
+  '@xyflow/svelte@1.2.1':
+    resolution: {integrity: sha512-RXE8Su8VNTvo+cUeSNuOd+fqs3X9ewofPndq4p4NrFADvfsrcFnHG6oWQ/945bcVKlvA9EkdDcT+jup8BhPr/w==}
+    peerDependencies:
+      svelte: ^5.25.0
+
   '@xyflow/system@0.0.14':
     resolution: {integrity: sha512-dmVQujAwZyoSZTr0sQHlgro9pS+RO9AgjT2BDlyB7t/+FYQBgW3FKdTQnVh8/azcdAncWruyiPt9K/h2kpTYrA==}
+
+  '@xyflow/system@0.0.65':
+    resolution: {integrity: sha512-AliQPQeurQMoNlOdySnRoDQl9yDSA/1Lqi47Eo0m98lHcfrTdD9jK75H0tiGj+0qRC10SKNUXyMkT0KL0opg4g==}
 
   '@zip.js/zip.js@2.7.54':
     resolution: {integrity: sha512-qMrJVg2hoEsZJjMJez9yI2+nZlBUxgYzGV3mqcb2B/6T1ihXp0fWBDYlVHlHquuorgNUQP5a8qSmX6HF5rFJNg==}
@@ -4259,6 +4334,9 @@ packages:
 
   electron-to-chromium@1.5.101:
     resolution: {integrity: sha512-L0ISiQrP/56Acgu4/i/kfPwWSgrzYZUnQrC0+QPFuhqlLP1Ir7qzPPDVS9BcKIyWTRU8+o6CC8dKw38tSWhYIA==}
+
+  elkjs@0.10.0:
+    resolution: {integrity: sha512-v/3r+3Bl2NMrWmVoRTMBtHtWvRISTix/s9EfnsfEWApNrsmNjqgqJOispCGg46BPwIFdkag3N/HYSxJczvCm6w==}
 
   elkjs@0.8.2:
     resolution: {integrity: sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==}
@@ -10610,6 +10688,10 @@ snapshots:
     dependencies:
       svelte: 3.59.2
 
+  '@svelte-put/shortcut@4.1.0(svelte@5.20.1)':
+    dependencies:
+      svelte: 5.20.1
+
   '@sveltejs/adapter-auto@1.0.3(@sveltejs/kit@1.30.4(svelte@3.59.2)(vite@4.5.5(@types/node@22.10.1)(sass@1.82.0)))':
     dependencies:
       '@sveltejs/kit': 1.30.4(svelte@3.59.2)(vite@4.5.5(@types/node@22.10.1)(sass@1.82.0))
@@ -11623,6 +11705,12 @@ snapshots:
       classcat: 5.0.5
       svelte: 3.59.2
 
+  '@xyflow/svelte@1.2.1(svelte@5.20.1)':
+    dependencies:
+      '@svelte-put/shortcut': 4.1.0(svelte@5.20.1)
+      '@xyflow/system': 0.0.65
+      svelte: 5.20.1
+
   '@xyflow/system@0.0.14':
     dependencies:
       '@types/d3': 7.4.3
@@ -11630,6 +11718,18 @@ snapshots:
       '@types/d3-selection': 3.0.11
       '@types/d3-zoom': 3.0.8
       d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
+  '@xyflow/system@0.0.65':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
 
@@ -12442,6 +12542,8 @@ snapshots:
     optional: true
 
   electron-to-chromium@1.5.101: {}
+
+  elkjs@0.10.0: {}
 
   elkjs@0.8.2: {}
 
@@ -14057,24 +14159,17 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.4.49):
+  postcss-import@15.1.0(postcss@8.5.2):
     dependencies:
-      postcss: 8.4.49
+      postcss: 8.5.2
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.10
 
-  postcss-js@4.0.1(postcss@8.4.49):
+  postcss-js@4.0.1(postcss@8.5.2):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.49
-
-  postcss-load-config@4.0.2(postcss@8.4.49):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.7.0
-    optionalDependencies:
-      postcss: 8.4.49
+      postcss: 8.5.2
 
   postcss-load-config@4.0.2(postcss@8.5.2):
     dependencies:
@@ -14082,7 +14177,6 @@ snapshots:
       yaml: 2.7.0
     optionalDependencies:
       postcss: 8.5.2
-    optional: true
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.2)(yaml@2.7.0):
     dependencies:
@@ -14092,9 +14186,9 @@ snapshots:
       postcss: 8.5.2
       yaml: 2.7.0
 
-  postcss-nested@6.2.0(postcss@8.4.49):
+  postcss-nested@6.2.0(postcss@8.5.2):
     dependencies:
-      postcss: 8.4.49
+      postcss: 8.5.2
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -15218,11 +15312,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.4.49
-      postcss-import: 15.1.0(postcss@8.4.49)
-      postcss-js: 4.0.1(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)
-      postcss-nested: 6.2.0(postcss@8.4.49)
+      postcss: 8.5.2
+      postcss-import: 15.1.0(postcss@8.5.2)
+      postcss-js: 4.0.1(postcss@8.5.2)
+      postcss-load-config: 4.0.2(postcss@8.5.2)
+      postcss-nested: 6.2.0(postcss@8.5.2)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.0


### PR DESCRIPTION
# 🗒 Description

Communication explorer migration to svelte 5 + svelte flow

- Communication Explorer right now
<img width="1505" height="778" alt="Screenshot 2025-07-28 at 16 55 54" src="https://github.com/user-attachments/assets/953d1e94-86f1-482b-9bb9-b4c10ab5eef1" />

- Current branch version with svelte flow
<img width="1503" height="774" alt="Screenshot 2025-07-28 at 16 55 37" src="https://github.com/user-attachments/assets/db4f70b0-0303-48a4-9e97-c9ad14e170c3" />

## Notes

- [ ] there is a reactive issue for the moment (one has to change the plugin after opening a file to display the diagram).
https://github.com/user-attachments/assets/2ea211d4-558b-41bd-85f0-9f30293cd724
- [ ] main goal is to be able to import the plugin into autodoc as a new block component.
<img width="1920" height="1080" alt="Edit Template_ Netzwerkübersicht_MitBaySelection" src="https://github.com/user-attachments/assets/82580bb8-5a63-459a-995f-a6e6f5bacf88" />
<img width="1920" height="1080" alt="Edit Template_ Netzwerkübersicht_V2" src="https://github.com/user-attachments/assets/b83c46fb-ee27-4471-b638-345abfa8fcb4" />


## Reminders

- `pnpm i`
- `pnpm dependencies:install`
- go to communication-explorer2 > `pnpm dev`
- open the link in your browser to make sure it loads correctly
- in open scd > paste the url from the console like this : `localhost:PORT/src/plugin.js`