### PR TITLE
Fix/design not loading properly

### DIFF
--- a/packages/plugins/communication-explorer/CHANGELOG.md
+++ b/packages/plugins/communication-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.37] - 11.11.2025
 ### Changed
 - Setup rollupOptions to bundle to a single file
+### Fixed
+- Set relative path for .css files
 
 ## [0.0.36] - 04.11.2025
 ### Changed

--- a/packages/plugins/communication-explorer/vite.config.ts
+++ b/packages/plugins/communication-explorer/vite.config.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path'
 const isDevelopment = process.env.NODE_ENV === 'development'
 
 export default defineConfig({
+    base: './',
     plugins: [
         svelte({
             compilerOptions: {

--- a/packages/plugins/type-switcher/CHANGELOG.md
+++ b/packages/plugins/type-switcher/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.17] - 11.11.2025
 ### Changed
 - Setup rollupOptions to bundle to a single file
+### Fixed
+- Set relative path for .css files
 
 ## [0.0.16] - 04.11.2025
 

--- a/packages/plugins/type-switcher/vite.config.ts
+++ b/packages/plugins/type-switcher/vite.config.ts
@@ -6,6 +6,7 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 
 // https://vite.dev/config/
 export default defineConfig({
+	base: './',
 	plugins: [
 		svelte({
 			compilerOptions: {


### PR DESCRIPTION
# 🗒 Description

.css files are absolute paths. Changed vite config so that these are relative. Hope this will fix the Design issue with Type Switcher too as localy it works fine. This seems to happen on inital load. Don't know what the cause is for the visual glitches.
- absolute /font.css
- relative oscd-plugins/type-switcher/font.css

## 📷 Demo screen recording or Screenshots

<img width="1078" height="514" alt="Screenshot 2025-11-11 at 16 07 14" src="https://github.com/user-attachments/assets/927b4cea-0cca-4770-99c4-de51ad196652" />

## 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [ ] Designated PR Reviewers are set
- [ ] Tested by another developer
- [x] Changelog updated
- [ ] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading )
- [ ] All comments in the PR are resolved / answered

## 🔦 Useful commits

You can add specific commits which are worth taking a look into

## ❌ Link issue(s) to close - [hint](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

You can add specific commits which are worth taking a look into

