### PR TITLE
fix: use relative paths for CSS files in auto-doc and network-explorer plugins

### DIFF
--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.7] - 14.11.2025
+### Fixed
+- Set relative path for .css files
+
 ## [1.17.6] - 11.11.2025
 ### Changed
 - Setup rollupOptions to bundle to a single file

--- a/packages/plugins/auto-doc/package.json
+++ b/packages/plugins/auto-doc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/auto-doc",
 	"private": true,
-	"version": "1.17.6",
+	"version": "1.17.7",
 	"type": "module",
 	"scripts": {
 		"//====== DEV ======//": "",

--- a/packages/plugins/auto-doc/vite.config.ts
+++ b/packages/plugins/auto-doc/vite.config.ts
@@ -6,6 +6,7 @@ import dts from 'vite-plugin-dts'
 const isDevelopment = process.env.NODE_ENV === 'development'
 
 export default defineConfig({
+	base: './',
 	plugins: [svelte(), dts({ rollupTypes: true })],
 	resolve: {
 		alias: {

--- a/packages/plugins/network-explorer/CHANGELOG.md
+++ b/packages/plugins/network-explorer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the communication explorer plugin will be documented here
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.14] - 14.11.2025
+### Fixed
+- Set relative path for .css files
+
 ## [0.0.13] - 13.11.2025
 ### Changed
 - Version bumped to 0.0.13 to avoid conflicts with older versions present on gh-pages. This ensures continuity and prevents overlap with previously published releases.

--- a/packages/plugins/network-explorer/package.json
+++ b/packages/plugins/network-explorer/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/network-explorer",
 	"private": true,
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"type": "module",
 	"scripts": {
 		"//====== DEV ======//": "",

--- a/packages/plugins/network-explorer/vite.config.ts
+++ b/packages/plugins/network-explorer/vite.config.ts
@@ -6,6 +6,7 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
+	base: './',
 	plugins: [
 		svelte({
 			compilerOptions: {


### PR DESCRIPTION
# 🗒 Description

Add the base path for .css files to ad and ne as well.

## 📷 Demo screen recording or Screenshots

- [x] Not applicable

## 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [x] Designated PR Reviewers are set
- [x] Tested by another developer
- [x] Changelog updated
- [x] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading )
- [x] All comments in the PR are resolved / answered

## 🔦 Useful commits

You can add specific commits which are worth taking a look into

## ❌ Link issue(s) to close - [hint](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

You can add specific commits which are worth taking a look into

