### PR TITLE
fix: add xyflow dependency to resolve import for NE

### DIFF
--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export to PNG feature for HTMLElements
 - Filter NE and CE preview for selected bays
 - Render NE and CE offscreen for document generation
+  ### Fixed
+- Added xyflow dependeny to resolve import for ne
 
 ## [1.17.7] - 2025-11-14
 ### Fixed

--- a/packages/plugins/auto-doc/package.json
+++ b/packages/plugins/auto-doc/package.json
@@ -41,6 +41,7 @@
 		"@tiptap/extension-underline": "^2.11.5",
 		"@tiptap/pm": "^2.11.5",
 		"@tiptap/starter-kit": "^2.11.5",
+		"@xyflow/svelte": "^1.5.0",
 		"jspdf": "^2.5.2",
 		"jspdf-autotable": "^3.8.4",
 		"uuid": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^2.11.5
         version: 2.11.5
+      '@xyflow/svelte':
+        specifier: ^1.5.0
+        version: 1.5.0(svelte@5.20.1)
       jspdf:
         specifier: ^2.5.2
         version: 2.5.2
@@ -4068,11 +4071,19 @@ packages:
     peerDependencies:
       svelte: ^5.25.0
 
+  '@xyflow/svelte@1.5.0':
+    resolution: {integrity: sha512-kHJVwMtabN7xthDJqLvx5wGT5qjOAVV90J9a26geDS51lrGsGb7CCxNRiZCMuVDlRkczGVIy9dkqdph6FL4slQ==}
+    peerDependencies:
+      svelte: ^5.25.0
+
   '@xyflow/system@0.0.14':
     resolution: {integrity: sha512-dmVQujAwZyoSZTr0sQHlgro9pS+RO9AgjT2BDlyB7t/+FYQBgW3FKdTQnVh8/azcdAncWruyiPt9K/h2kpTYrA==}
 
   '@xyflow/system@0.0.72':
     resolution: {integrity: sha512-WBI5Aau0fXTXwxHPzceLNS6QdXggSWnGjDtj/gG669crApN8+SCmEtkBth1m7r6pStNo/5fI9McEi7Dk0ymCLA==}
+
+  '@xyflow/system@0.0.74':
+    resolution: {integrity: sha512-7v7B/PkiVrkdZzSbL+inGAo6tkR/WQHHG0/jhSvLQToCsfa8YubOGmBYd1s08tpKpihdHDZFwzQZeR69QSBb4Q==}
 
   '@zip.js/zip.js@2.7.54':
     resolution: {integrity: sha512-qMrJVg2hoEsZJjMJez9yI2+nZlBUxgYzGV3mqcb2B/6T1ihXp0fWBDYlVHlHquuorgNUQP5a8qSmX6HF5rFJNg==}
@@ -11009,6 +11020,10 @@ snapshots:
     dependencies:
       svelte: 3.59.2
 
+  '@svelte-put/shortcut@4.1.0(svelte@5.20.1)':
+    dependencies:
+      svelte: 5.20.1
+
   '@svelte-put/shortcut@4.1.0(svelte@5.43.5)':
     dependencies:
       svelte: 5.43.5
@@ -12101,6 +12116,12 @@ snapshots:
       '@xyflow/system': 0.0.72
       svelte: 5.43.5
 
+  '@xyflow/svelte@1.5.0(svelte@5.20.1)':
+    dependencies:
+      '@svelte-put/shortcut': 4.1.0(svelte@5.20.1)
+      '@xyflow/system': 0.0.74
+      svelte: 5.20.1
+
   '@xyflow/system@0.0.14':
     dependencies:
       '@types/d3': 7.4.3
@@ -12112,6 +12133,18 @@ snapshots:
       d3-zoom: 3.0.0
 
   '@xyflow/system@0.0.72':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
+  '@xyflow/system@0.0.74':
     dependencies:
       '@types/d3-drag': 3.0.7
       '@types/d3-interpolate': 3.0.4


### PR DESCRIPTION
# 🗒 Description

The error:
https://github.com/sprinteins/oscd-plugins/actions/runs/20028269244/job/57529710370
- We just add xyflow as a dependency in Auto Doc to test if it works as a workaround.
  - Testing if there will be more packages that will get this error
  - Otherwise we might need to create the Components that AD will import differently. 

## 📷 Demo screen recording or Screenshots

- [x] Not applicable

## 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [ ] Designated PR Reviewers are set
- [ ] Tested by another developer
- [x] Changelog updated
- [x] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading )
- [x] All comments in the PR are resolved / answered

## 🔦 Useful commits

You can add specific commits which are worth taking a look into

## ❌ Link issue(s) to close - [hint](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

