### PR TITLE
fix(dist): update tsconfig to ignore deprecations

### DIFF
--- a/packages/plugins/type-distributor/tsconfig.json
+++ b/packages/plugins/type-distributor/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "@tsconfig/svelte/tsconfig.json",
 	"compilerOptions": {
 		"baseUrl": ".",
+		"ignoreDeprecations": "6.0",
 		"target": "ESNext",
 		"useDefineForClassFields": true,
 		"module": "ESNext",


### PR DESCRIPTION
# 🗒 Description

Option baseUrl is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption 
 to silence this error.

## 📷 Demo screen recording or Screenshots

- [x] Not applicable

## 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [x] Designated PR Reviewers are set
- [x] Tested by another developer
- [x] Changelog updated
- [x] Documentation updated (check [Documentation guidelines](../doc/guidelines/doc_guidelines.md) for further reading )
- [x] All comments in the PR are resolved / answered

## 🔦 Useful commits

You can add specific commits which are worth taking a look into

## ❌ Link issue(s) to close - [hint](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

closes #689 
