### PR TITLE
fix: styles lost in the type switcher due to specificity

### DIFF
--- a/packages/plugins/type-switcher/CHANGELOG.md
+++ b/packages/plugins/type-switcher/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.19] - 2026-04-13
+### Fixed
+- Styles lost on the group card due to specificity [#639](https://github.com/sprinteins/oscd-plugins/issues/639)
+
 ## [0.0.18] - 2026-01-16
 ### Changed
 - Receive `editor` property from Plugin API

--- a/packages/plugins/type-switcher/package.json
+++ b/packages/plugins/type-switcher/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/type-switcher",
 	"private": true,
-	"version": "0.0.18",
+	"version": "0.0.19",
 	"type": "module",
 	"scripts": {
 		"//====== DEV ======//": "",

--- a/packages/plugins/type-switcher/src/ui/components/group-card/group-card.svelte
+++ b/packages/plugins/type-switcher/src/ui/components/group-card/group-card.svelte
@@ -29,80 +29,28 @@ let titleText = $derived(items.join('\n'))
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  class="group-card"
-  style="display: grid; grid-template-columns: 1fr 3rem;"
-  {onclick}
-  {onkeydown}
-  data-testid={dataTestid}
-  class:selected
-  title={titleText}
-><div class="left">
-    {#if icon}
-      <div class="icon-placeholder">
-        <Icons name={icon} size="rect" />
-      </div>
-    {:else}
-      {null}
-    {/if}
-    <ul>
-      {#each displayedItems as item}
-        <li>{item}</li>
-      {/each}
-    </ul>
-  </div><span class="right">
-    <Counter count={items.length} />
-  </span>
+	class="box-border h-[90px] cursor-pointer rounded-lg border bg-[var(--mdc-theme-surface)] transition-all duration-100 {selected
+		? 'border-[var(--mdc-theme-primary)] shadow'
+		: 'border-transparent hover:border-dashed hover:border-[var(--mdc-theme-primary)]'}"
+	style="display: grid; grid-template-columns: 1fr 3rem;"
+	{onclick}
+	{onkeydown}
+	data-testid={dataTestid}
+	title={titleText}
+>
+	<div class="overflow-hidden py-2 pl-3">
+		{#if icon}
+			<div class="pb-[0.2rem]">
+				<Icons name={icon} size="rect" />
+			</div>
+		{/if}
+		<ul class="m-0 list-none p-0 leading-[1.15]">
+			{#each displayedItems as item}
+				<li class="truncate">{item}</li>
+			{/each}
+		</ul>
+	</div>
+	<span class="p-2">
+		<Counter count={items.length} />
+	</span>
 </div>
-
-<style lang="scss">
-  .group-card {
-    cursor: pointer;
-    height: 90px;
-    padding: 0rem;
-
-    background: var(--mdc-theme-surface);
-
-    transition: all 100ms;
-    box-sizing: border-box;
-
-    border: transparent 1px solid;
-    border-radius: 0.5rem;
-
-    &.selected {
-      border-color: var(--mdc-theme-primary);
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-    }
-
-    &:hover:not(.selected) {
-      /* background: var(--color-beige-3); */
-      border-style: dashed;
-      border-color: var(--mdc-theme-primary);
-    }
-
-    .left {
-      padding: 0.5rem 0 0.5rem 0.75rem;
-
-      overflow: hidden;
-    }
-
-    .right {
-      padding: 0.5rem;
-    }
-
-    ul {
-      padding: 0;
-      margin: 0;
-      line-height: 1.15;
-    }
-
-    li {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-    .icon-placeholder {
-      padding-bottom: 0.2rem;
-      //margin-top: 0.5rem;
-    }
-  }
-</style>

--- a/packages/plugins/type-switcher/src/ui/components/group-card/group-card.svelte
+++ b/packages/plugins/type-switcher/src/ui/components/group-card/group-card.svelte
@@ -1,42 +1,42 @@
 <script lang="ts">
-  import { Counter } from "@oscd-plugins/ui";
-  import { Icons, type IconKeys } from "@oscd-plugins/ui";
+import { Counter } from '@oscd-plugins/ui'
+import { Icons, type IconKeys } from '@oscd-plugins/ui'
 
-  interface Props {
-    // Input
-    onclick?: (e: Event) => void;
-    onkeydown?: (e: KeyboardEvent) => void;
-    items?: string[];
-    icon: IconKeys | undefined;
-    dataTestid?: string;
-    selected?: boolean;
-  }
+interface Props {
+	// Input
+	onclick?: (e: Event) => void
+	onkeydown?: (e: KeyboardEvent) => void
+	items?: string[]
+	icon: IconKeys | undefined
+	dataTestid?: string
+	selected?: boolean
+}
 
-  let {
-    onclick,
-    onkeydown,
-    items = [],
-    icon,
-    dataTestid = "",
-    selected = false,
-  }: Props = $props();
+let {
+	onclick,
+	onkeydown,
+	items = [],
+	icon,
+	dataTestid = '',
+	selected = false
+}: Props = $props()
 
-  // Internal
-  const MAX_NR_OF_ITEMS = 3;
-  let displayedItems = $derived(items.slice(0, MAX_NR_OF_ITEMS));
-  let titleText = $derived(items.join("\n"));
+// Internal
+const MAX_NR_OF_ITEMS = 3
+let displayedItems = $derived(items.slice(0, MAX_NR_OF_ITEMS))
+let titleText = $derived(items.join('\n'))
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="group-card"
+  style="display: grid; grid-template-columns: 1fr 3rem;"
   {onclick}
   {onkeydown}
   data-testid={dataTestid}
   class:selected
   title={titleText}
->
-  <div class="left">
+><div class="left">
     {#if icon}
       <div class="icon-placeholder">
         <Icons name={icon} size="rect" />
@@ -49,23 +49,18 @@
         <li>{item}</li>
       {/each}
     </ul>
-  </div>
-  <span class="right">
+  </div><span class="right">
     <Counter count={items.length} />
   </span>
 </div>
 
 <style lang="scss">
   .group-card {
-    display: inline-grid;
-
     cursor: pointer;
     height: 90px;
     padding: 0rem;
 
     background: var(--mdc-theme-surface);
-
-    grid-template-columns: 1fr min(3rem);
 
     transition: all 100ms;
     box-sizing: border-box;

--- a/packages/plugins/type-switcher/src/ui/components/group-card/group-card.svelte
+++ b/packages/plugins/type-switcher/src/ui/components/group-card/group-card.svelte
@@ -29,10 +29,9 @@ let titleText = $derived(items.join('\n'))
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-	class="box-border h-[90px] cursor-pointer rounded-lg border bg-[var(--mdc-theme-surface)] transition-all duration-100 {selected
+	class="grid grid-cols-[1fr_3rem] box-border h-[90px] cursor-pointer rounded-lg border bg-[var(--mdc-theme-surface)] transition-all duration-100 {selected
 		? 'border-[var(--mdc-theme-primary)] shadow'
 		: 'border-transparent hover:border-dashed hover:border-[var(--mdc-theme-primary)]'}"
-	style="display: grid; grid-template-columns: 1fr 3rem;"
 	{onclick}
 	{onkeydown}
 	data-testid={dataTestid}


### PR DESCRIPTION
# 🗒 Description

Styles were lost as somehow the specificity was lost. Likely due to Shadow DOM and bundled web components.

## 📷 Demo screen recording or Screenshots

- [x] Not applicable

## 📋 Checklist

You may remove tasks that do not make sense in this PR.

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [x] Designated PR Reviewers are set
- [x] Tested by another developer
- [x] Changelog updated
- [x] All comments in the PR are resolved / answered

## ❌ Link issue(s) to close

closes #639 
