### PR TITLE
feat(td): simplify drag and drop to be the same as in dist

### DIFF
--- a/packages/plugins/type-designer/CHANGELOG.md
+++ b/packages/plugins/type-designer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.2] - 2026-04-21
+### Changed
+- Uses now the drag and drop behavior from the type distributor
+
 ## [3.16.1] - 2026-01-16
 ### Changed
 - Receive `editor` property from Plugin API

--- a/packages/plugins/type-designer/package.json
+++ b/packages/plugins/type-designer/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/type-designer",
 	"private": true,
-	"version": "3.16.1",
+	"version": "3.16.2",
 	"type": "module",
 	"source": "src/plugin.ts",
 	"scripts": {

--- a/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
+++ b/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
@@ -44,11 +44,9 @@ const {
 // local states
 let isElementCardOpen = $state(false)
 let isCurrentDropTarget = $state(false)
-let hoverExpandTimeout: ReturnType<typeof setTimeout> | null = null
+let hoverExpandTimeout: NodeJS.Timeout | null = $state(null)
 
 //======= DERIVED STATES =======//
-
-const isLNodeType = $derived(typeElementFamily === TYPE_FAMILY.lNodeType)
 
 const currentRefs = $derived.by(() => {
 	if (importScope)
@@ -139,6 +137,7 @@ const handleDragLeave = (event: DragEvent) => {
 	const dropZone = event.currentTarget as HTMLElement
 	if (!dropZone?.contains(event.relatedTarget as Node | null)) {
 		isCurrentDropTarget = false
+		isElementCardOpen = false
 		if (hoverExpandTimeout) {
 			clearTimeout(hoverExpandTimeout)
 			hoverExpandTimeout = null
@@ -161,6 +160,11 @@ const handleDrop = (event: DragEvent) => {
 }
 
 //======= EFFECTS =======//
+
+// autoclose collapsible if no refs are present
+$effect(() => {
+	if (!hasRefs) isElementCardOpen = false
+})
 
 // handle last element with drag and drop
 // to scroll the column content element to bottom

--- a/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
+++ b/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
@@ -45,7 +45,6 @@ const {
 // local states
 let isElementCardOpen = $state(false)
 let isCurrentDropTarget = $state(false)
-let hoverTimeout: NodeJS.Timeout | null = $state(null)
 
 //======= DERIVED STATES =======//
 
@@ -130,49 +129,24 @@ const handleDragOver = (event: DragEvent) => {
 	isCurrentDropTarget = true
 }
 
-const handleOpenCollapsible = (event: DragEvent) => {
-	event.preventDefault()
-	if (isLNodeType || !isAllowedToDrop) return
-
-	if (!hoverTimeout)
-		hoverTimeout = setTimeout(() => {
-			isElementCardOpen = true
-			if (!hasRefs) isCurrentDropTarget = true
-			hoverTimeout = null
-		}, 200)
-}
-
-const handleCloseCollapsible = (event: DragEvent) => {
-	event.preventDefault()
-	if (isLNodeType || !isAllowedToDrop) return
-
-	const dropZone = event.currentTarget as HTMLElement
-	if (!dropZone?.contains(event.relatedTarget as Node | null)) {
-		isCurrentDropTarget = false
-		isElementCardOpen = false
-	}
-
-	if (hoverTimeout) {
-		clearTimeout(hoverTimeout)
-		hoverTimeout = null
-	}
-}
-
 const handleDragLeave = (event: DragEvent) => {
-	if (!isAllowedToDrop) return
 	const dropZone = event.currentTarget as HTMLElement
 	if (!dropZone?.contains(event.relatedTarget as Node | null)) {
 		isCurrentDropTarget = false
-		isElementCardOpen = false
 	}
+}
+
+const handleDrop = (event: DragEvent) => {
+	event.preventDefault()
+	if (!isAllowedToDrop) return
+	isCurrentDropTarget = false
+	dndStore.handleDrop({
+		parentTypeWrapper: typeElement.element,
+		parentTypeFamily: typeElementFamily
+	})
 }
 
 //======= EFFECTS =======//
-
-// autoclose collapsible if no refs are present
-$effect(() => {
-	if (!hasRefs) isElementCardOpen = false
-})
 
 // handle last element with drag and drop
 // to scroll the column content element to bottom
@@ -185,93 +159,52 @@ $effect(() => {
 })
 </script>
 
-<Collapsible.Root 
-	bind:open={isElementCardOpen} 
+<Collapsible.Root
+	bind:open={isElementCardOpen}
 	class="space-y-1 mb-2"
-	ondragover={importScope ? undefined : handleOpenCollapsible}
-	ondragleave={importScope ? undefined : handleCloseCollapsible}
-	ondrop={importScope ? undefined : handleCloseCollapsible}
 >
-	<TypeCard {typeElement} {typeElementKey} {typeElementFamily} {isElementCardOpen} {importScope} />
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="relative"
+		ondragover={importScope ? undefined : handleDragOver}
+		ondragleave={importScope ? undefined : handleDragLeave}
+		ondrop={importScope ? undefined : handleDrop}
+	>
+		<TypeCard {typeElement} {typeElementKey} {typeElementFamily} {isElementCardOpen} {importScope} />
+		{#if isCurrentDropTarget && isAllowedToDrop}
+			<div class="absolute inset-0 rounded-lg border-2 border-primary ring-2 ring-primary ring-offset-1 pointer-events-none"></div>
+			<CirclePlus class="absolute right-2 top-1.5 size-5 text-primary animate-pulse pointer-events-none" />
+		{/if}
+	</div>
 
-	<Collapsible.Content class="space-y-1 flex flex-col items-end relative"
-		ondragover={handleDragOver}
-		ondragleave={handleDragLeave}
-		ondrop={(event) => {
-			event.preventDefault();
-			if(!isAllowedToDrop) return
-			isCurrentDropTarget = false;
-			dndStore.handleDrop({
-				parentTypeWrapper: typeElement.element,
-				parentTypeFamily: typeElementFamily
-			});
-		}}>
-		
+	<Collapsible.Content class="space-y-1 flex flex-col items-end">
 		{#snippet child({ props, open: collapsibleContentOpen })}
 			{#if collapsibleContentOpen}
-				<div {...props} transition:slide={{ duration: 100 }}  >
-					<!-- DND DROP ZONE START -->
-					{#if isAllowedToDrop}
-						<div 
-							class={`${isCurrentDropTarget ? 'flex' : 'hidden'} dropzone`}
-						>
-							<CirclePlus class="size-16 text-primary stroke-2" />
-						</div>
-					{/if}
-					<!-- DND DROP ZONE END -->
-
+				<div {...props} transition:slide={{ duration: 100 }}>
 					<!-- REFS CARDS START -->
 					{#if typeElementFamily !== TYPE_FAMILY.lNodeType}
-						{#if hasRefs}
-							{#each currentRefs as [refFamily, refElements]}
-								{#each Object.entries(refElements) as [refId, refWrapper]} 
-									<Card.Root class="w-5/6">
-										<Card.Content class="h-8 p-1 flex items-center justify-between">
-											<div class="flex items-center min-w-0 w-full">
-												<span class="ml-3 min-w-2.5 min-h-2.5 border-teal-700 border-2 transform rotate-45"></span>
-												<span class="ml-4 truncate">{ getCurrentRefFullLabel(refWrapper) }</span>
-												{#if shouldShowBadge(refFamily)}
-													<Badge.Root class="bg-transparent border-gray-600 border-2 rounded-sm text-gray-600 hover:bg-transparent ml-auto">{ getBadgeLabel(refFamily) }</Badge.Root>
-												{/if}
-											</div>
-											{#if !importScope}
-												<CardMenu type={{ family: typeElementFamily, id: typeElementKey}} ref={{ family: refFamily, id: refId}}/>
+						{#each currentRefs as [refFamily, refElements]}
+							{#each Object.entries(refElements) as [refId, refWrapper]}
+								<Card.Root class="w-5/6">
+									<Card.Content class="h-8 p-1 flex items-center justify-between">
+										<div class="flex items-center min-w-0 w-full">
+											<span class="ml-3 min-w-2.5 min-h-2.5 border-teal-700 border-2 transform rotate-45"></span>
+											<span class="ml-4 truncate">{ getCurrentRefFullLabel(refWrapper) }</span>
+											{#if shouldShowBadge(refFamily)}
+												<Badge.Root class="bg-transparent border-gray-600 border-2 rounded-sm text-gray-600 hover:bg-transparent ml-auto">{ getBadgeLabel(refFamily) }</Badge.Root>
 											{/if}
-										</Card.Content>
-									</Card.Root>
-								{/each}
+										</div>
+										{#if !importScope}
+											<CardMenu type={{ family: typeElementFamily, id: typeElementKey}} ref={{ family: refFamily, id: refId}}/>
+										{/if}
+									</Card.Content>
+								</Card.Root>
 							{/each}
-						{:else}
-
-							<!-- DND INVISIBLE PLACEHOLDER START -->
-							<div class="w-5/6 h-8 invisible"></div>
-							<!-- DND INVISIBLE PLACEHOLDER END -->
-
-						{/if}
+						{/each}
 					{/if}
 					<!-- REFS CARDS END -->
 				</div>
 			{/if}
 		{/snippet}
-
 	</Collapsible.Content>
 </Collapsible.Root>
-
-<style>
-.dropzone{
-	@apply 
-		absolute
-		min-h-8
-		top-0
-		left-0
-		right-0
-		bottom-0
-		bg-primary/20
-		border-4
-		border-dashed
-		border-primary
-		flex-col
-		items-center
-		justify-center;
-}
-</style>

--- a/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
+++ b/packages/plugins/type-designer/src/ui/components/element-card/card-collapsible-wrapper.svelte
@@ -12,7 +12,6 @@ import { slide } from 'svelte/transition'
 import { Card, Collapsible, Badge } from '@oscd-plugins/core-ui-svelte'
 import TypeCard from './type-card.svelte'
 import CardMenu from './card-menu.svelte'
-import { CirclePlus } from 'lucide-svelte'
 // TYPES
 import type {
 	TypeElement,
@@ -45,6 +44,7 @@ const {
 // local states
 let isElementCardOpen = $state(false)
 let isCurrentDropTarget = $state(false)
+let hoverExpandTimeout: ReturnType<typeof setTimeout> | null = null
 
 //======= DERIVED STATES =======//
 
@@ -127,12 +127,22 @@ const handleDragOver = (event: DragEvent) => {
 	event.preventDefault()
 	if (!isAllowedToDrop) return
 	isCurrentDropTarget = true
+	if (!isElementCardOpen && !hoverExpandTimeout) {
+		hoverExpandTimeout = setTimeout(() => {
+			isElementCardOpen = true
+			hoverExpandTimeout = null
+		}, 600)
+	}
 }
 
 const handleDragLeave = (event: DragEvent) => {
 	const dropZone = event.currentTarget as HTMLElement
 	if (!dropZone?.contains(event.relatedTarget as Node | null)) {
 		isCurrentDropTarget = false
+		if (hoverExpandTimeout) {
+			clearTimeout(hoverExpandTimeout)
+			hoverExpandTimeout = null
+		}
 	}
 }
 
@@ -140,6 +150,10 @@ const handleDrop = (event: DragEvent) => {
 	event.preventDefault()
 	if (!isAllowedToDrop) return
 	isCurrentDropTarget = false
+	if (hoverExpandTimeout) {
+		clearTimeout(hoverExpandTimeout)
+		hoverExpandTimeout = null
+	}
 	dndStore.handleDrop({
 		parentTypeWrapper: typeElement.element,
 		parentTypeFamily: typeElementFamily
@@ -159,21 +173,20 @@ $effect(() => {
 })
 </script>
 
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	ondragover={importScope ? undefined : handleDragOver}
+	ondragleave={importScope ? undefined : handleDragLeave}
+	ondrop={importScope ? undefined : handleDrop}
+>
 <Collapsible.Root
 	bind:open={isElementCardOpen}
 	class="space-y-1 mb-2"
 >
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div
-		class="relative"
-		ondragover={importScope ? undefined : handleDragOver}
-		ondragleave={importScope ? undefined : handleDragLeave}
-		ondrop={importScope ? undefined : handleDrop}
-	>
+	<div class="relative">
 		<TypeCard {typeElement} {typeElementKey} {typeElementFamily} {isElementCardOpen} {importScope} />
 		{#if isCurrentDropTarget && isAllowedToDrop}
 			<div class="absolute inset-0 rounded-lg border-2 border-primary ring-2 ring-primary ring-offset-1 pointer-events-none"></div>
-			<CirclePlus class="absolute right-2 top-1.5 size-5 text-primary animate-pulse pointer-events-none" />
 		{/if}
 	</div>
 
@@ -208,3 +221,4 @@ $effect(() => {
 		{/snippet}
 	</Collapsible.Content>
 </Collapsible.Root>
+</div>

--- a/packages/plugins/type-distributor/CHANGELOG.md
+++ b/packages/plugins/type-distributor/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1-0-6] 2026-04-21
+### Changed
+- the behavior of the drag and drop so it closes and opens the accesspoint
+- allow to drag inside the children of the accesspoint
+
 ## [1.0.5] 2026-04-09
 ### Added
 - Validation of the SSD to include mandatory LLN0 Type and its mandatory DOs [#719](https://github.com/sprinteins/oscd-plugins/issues/719)

--- a/packages/plugins/type-distributor/package.json
+++ b/packages/plugins/type-distributor/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@oscd-plugins/type-distributor",
 	"private": true,
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"type": "module",
 	"scripts": {
 		"//====== DEV ======//": "",

--- a/packages/plugins/type-distributor/src/ui/components/columns/s-ied/access-point.svelte
+++ b/packages/plugins/type-distributor/src/ui/components/columns/s-ied/access-point.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { ChevronRight, CirclePlus } from '@lucide/svelte'
+import { ChevronRight } from '@lucide/svelte'
 import {
 	Card,
 	DropdownMenuWorkaround,
@@ -24,6 +24,7 @@ const { accessPoint, apName, lDevices, iedName, iedElement }: Props = $props()
 let isOpen = $state(false)
 let hasLDevices = $derived(lDevices.length > 0)
 let isDropTarget = $state(false)
+let hoverExpandTimeout: ReturnType<typeof setTimeout> | null = null
 
 let isInUse = $derived(lDevices.some((ld) => !ld.ldInst?.startsWith('LD0')))
 
@@ -33,6 +34,12 @@ function handleDragOver(event: DragEvent) {
 	event.preventDefault()
 	if (!dndStore.isDragging) return
 	isDropTarget = true
+	if (!isOpen && hasLDevices && !hoverExpandTimeout) {
+		hoverExpandTimeout = setTimeout(() => {
+			isOpen = true
+			hoverExpandTimeout = null
+		}, 600)
+	}
 }
 
 function handleDragLeave(event: DragEvent) {
@@ -40,12 +47,20 @@ function handleDragLeave(event: DragEvent) {
 	const currentTarget = event.currentTarget as HTMLElement
 	if (!currentTarget?.contains(relatedTarget)) {
 		isDropTarget = false
+		if (hoverExpandTimeout) {
+			clearTimeout(hoverExpandTimeout)
+			hoverExpandTimeout = null
+		}
 	}
 }
 
 function handleDrop(event: DragEvent) {
 	event.preventDefault()
 	isDropTarget = false
+	if (hoverExpandTimeout) {
+		clearTimeout(hoverExpandTimeout)
+		hoverExpandTimeout = null
+	}
 
 	if (!dndStore.currentDraggedItem) {
 		console.warn('[AccessPoint] No dragged item in store')
@@ -71,13 +86,16 @@ async function handleRename() {
 }
 </script>
 
-<div class="space-y-1">
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="space-y-1"
+  ondragover={handleDragOver}
+  ondragleave={handleDragLeave}
+  ondrop={handleDrop}
+>
   <button
     class="w-full"
     onclick={() => hasLDevices && (isOpen = !isOpen)}
-    ondragover={handleDragOver}
-    ondragleave={handleDragLeave}
-    ondrop={handleDrop}
   >
     <Card.Root
       class="{isInUse
@@ -104,9 +122,6 @@ async function handleRename() {
             </span>
           </div>
           <div class="flex items-center gap-2 shrink-0">
-            {#if isDropTarget}
-              <CirclePlus class="size-5 text-primary animate-pulse" />
-            {/if}
             <span
               onclick={(e) => e.stopPropagation()}
               role="button"

--- a/packages/plugins/type-distributor/src/ui/components/columns/s-ied/access-point.svelte
+++ b/packages/plugins/type-distributor/src/ui/components/columns/s-ied/access-point.svelte
@@ -24,7 +24,7 @@ const { accessPoint, apName, lDevices, iedName, iedElement }: Props = $props()
 let isOpen = $state(false)
 let hasLDevices = $derived(lDevices.length > 0)
 let isDropTarget = $state(false)
-let hoverExpandTimeout: ReturnType<typeof setTimeout> | null = null
+let hoverExpandTimeout: NodeJS.Timeout | null = $state(null)
 
 let isInUse = $derived(lDevices.some((ld) => !ld.ldInst?.startsWith('LD0')))
 
@@ -47,6 +47,7 @@ function handleDragLeave(event: DragEvent) {
 	const currentTarget = event.currentTarget as HTMLElement
 	if (!currentTarget?.contains(relatedTarget)) {
 		isDropTarget = false
+		isOpen = false
 		if (hoverExpandTimeout) {
 			clearTimeout(hoverExpandTimeout)
 			hoverExpandTimeout = null


### PR DESCRIPTION
# 🗒 Description

- Uses the same drag and drop behavior for both Type Designer and Type Distributor
- It is possible to drag into the "children" of the parent, but it shows only that its getting add to the parent.
- The user can't decide where exactly in the order it should be added
- Removed difficult to see (+) icon
- Opens the children after a short period of hovering over the parent.

## 📷 Demo screen recording or Screenshots

Type Distributor:

https://github.com/user-attachments/assets/0c4f027e-7b61-4001-add1-1836192c1dff

Type Designer:

https://github.com/user-attachments/assets/f6cd4738-8b37-4ff8-a3e1-a83354aeb70f

## 📋 Checklist

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [x] Designated PR Reviewers are set
- [x] Tested by another developer
- [x] Changelog updated
- [x] All comments in the PR are resolved / answered

## ❌ Link issue(s) to close

closes #722 
