### PR TITLE
fix(ad): reset templateId when navigating to create a new template

### DIFF
--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-04-21
+### Fixed
+- creating "new" template reopening the latest used template
+
 ## [1.18.11] - 2026-02-16
 ### Fixed
 - Hint page overflow

--- a/packages/plugins/auto-doc/src/ui/components/views/template-overview/template-overview.svelte
+++ b/packages/plugins/auto-doc/src/ui/components/views/template-overview/template-overview.svelte
@@ -31,7 +31,7 @@ function fetchTemplates() {
 }
 
 function navigateToCreateTemplate() {
-	navigate({ view: View.Create })
+	navigate({ view: View.Create, templateId: null })
 }
 
 async function onImportTemplate(file: File) {

--- a/packages/plugins/auto-doc/src/ui/components/views/view-navigator/view-navigator.svelte
+++ b/packages/plugins/auto-doc/src/ui/components/views/view-navigator/view-navigator.svelte
@@ -11,6 +11,7 @@ let viewState = $state<ViewState>({
 function navigate(newViewState: Partial<ViewState>): void {
 	viewState = {
 		...viewState,
+		templateId: null,
 		...newViewState
 	}
 }


### PR DESCRIPTION
# 🗒 Description

Fixed an issue where the template did not create a "new" template and reused the latest used template.

## 📋 Checklist

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [x] Designated PR Reviewers are set
- [x] Tested by another developer
- [x] Changelog updated
- [x] All comments in the PR are resolved / answered

## ❌ Link issue(s) to close

closes #683 
