### PR TITLE
feat(ad): use button to rename and sort templates by date

### DIFF
--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] 2026-04-21
+## [Unreleased] - 2026-04-21
 ### Added
 - button to edit title and description of a template
 ### Changed

--- a/packages/plugins/auto-doc/CHANGELOG.md
+++ b/packages/plugins/auto-doc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] 2026-04-21
+### Added
+- button to edit title and description of a template
+### Changed
+- sorting order of templates by date to have the latest at the top
+
 ## [1.18.11] - 2026-02-16
 ### Fixed
 - Hint page overflow

--- a/packages/plugins/auto-doc/src/ui/components/views/template-creation/template-creation.svelte
+++ b/packages/plugins/auto-doc/src/ui/components/views/template-creation/template-creation.svelte
@@ -2,7 +2,7 @@
 import { type NavigateProps, View } from '../view-navigator/view'
 import { clickOutside } from '@/actions'
 import { docTemplatesStore } from '@/stores'
-import { TemplateBuilder, Tooltip } from '@/ui/components'
+import { TemplateBuilder } from '@/ui/components'
 import { pdfGenerator } from '@/pdf'
 import { CustomIconButton } from '@oscd-plugins/ui/src/components'
 import Button, { Label } from '@smui/button'
@@ -117,18 +117,14 @@ function downloadTemplateContent(
           color="black"
           onclick={askForEmptyTitleConfirmation}
         />
-        <Tooltip text="Rename">
-          <div
-            class="title"
-            role="button"
-            tabindex="0"
-            onclick={(e) => displayTitleAndDescription(e)}
-            onkeydown={(e) =>
-              e.key === "Enter" && displayTitleAndDescription(e)}
-          >
-            {templateTitle}
-          </div>
-        </Tooltip>
+        <div class="title">
+          {templateTitle}
+        </div>
+        <CustomIconButton
+          icon="edit"
+          size="small"
+          onclick={(e) => displayTitleAndDescription(e)}
+        />
       </div>
       <div>
         <div>
@@ -215,16 +211,14 @@ function downloadTemplateContent(
   .template-title {
     display: flex;
     align-items: center;
-    cursor: pointer;
+    gap: 0;
     & .title {
-      min-width: 10rem;
+      margin-left: 0.5rem;
       color: black;
-    }
-    .title:hover {
-      cursor: pointer;
-      border-radius: 2px;
-      outline: 2px solid gray;
-      outline-offset: 2px;
+      max-width: 20rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
   .template-options {

--- a/packages/plugins/auto-doc/src/ui/components/views/template-overview/template-overview.svelte
+++ b/packages/plugins/auto-doc/src/ui/components/views/template-overview/template-overview.svelte
@@ -102,7 +102,9 @@ function openFileSelectorIfNotMasterTemplate() {
 }
 
 let templatesConvertedToTableRow = $derived(
-	allTemplates.map(mapElementToTableRow)
+	allTemplates
+		.map(mapElementToTableRow)
+		.sort((a, b) => b.lastEdited.getTime() - a.lastEdited.getTime())
 )
 $effect(() => {
 	docTemplatesStore.setMasterTemplateFlag(isMasterTemplate)


### PR DESCRIPTION
# 🗒 Description

- Add button to edit title and description
- Sort templates by date and time so the latest is at the top

## 📷 Demo screen recording or Screenshots

- [x] Not applicable

## 📋 Checklist

- [x] Ticket-ACs are checked and met
- [x] GitHub **labels** are assigned
- [x] Git Ticket / issue  is linked with PR
- [ ] Designated PR Reviewers are set
- [ ] Tested by another developer
- [x] Changelog updated
- [ ] All comments in the PR are resolved / answered

## ❌ Link issue(s) to close

closes #684 
