### PR TITLE
feat(type-distributor): add CoMPAS file loading

### DIFF
--- a/packages/plugins/type-distributor/src/headless/import/index.ts
+++ b/packages/plugins/type-distributor/src/headless/import/index.ts
@@ -1,5 +1,6 @@
 export {
 	INVALID_XML_IMPORT_MESSAGE,
+	loadFromCompas,
 	loadFromLocal,
 	NO_FILE_SELECTED_MESSAGE
 } from './load-file.helper'

--- a/packages/plugins/type-distributor/src/headless/import/load-file.helper.ts
+++ b/packages/plugins/type-distributor/src/headless/import/load-file.helper.ts
@@ -1,9 +1,18 @@
+import { dialogStore } from '@oscd-plugins/core-ui-svelte'
 import { ssdImportStore } from '@/headless/stores/ssd-import.store.svelte'
+import ImportDialog from '@/ui/components/compas/import-dialog.svelte'
 
 export const INVALID_XML_IMPORT_MESSAGE =
 	'The selected file is not a valid XML SSD.'
 
 export const NO_FILE_SELECTED_MESSAGE = 'No file selected'
+
+export async function loadFromCompas() {
+	dialogStore.mountInnerComponent({
+		innerComponent: ImportDialog
+	})
+	await dialogStore.openDialog()
+}
 
 export async function loadFromLocal() {
 	const file = ssdImportStore.fileInput?.files?.[0]

--- a/packages/plugins/type-distributor/src/ui/components/compas/import-dialog.svelte
+++ b/packages/plugins/type-distributor/src/ui/components/compas/import-dialog.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+// SVELTE
+import { fly } from 'svelte/transition'
+import { cubicOut } from 'svelte/easing'
+// CORE
+import {
+	dialogStore,
+	compasStore,
+	Button,
+	Separator
+} from '@oscd-plugins/core-ui-svelte'
+// STORES
+import { ssdImportStore } from '@/headless/stores/ssd-import.store.svelte'
+// COMPONENTS
+import { MoveLeft, LoaderCircle, Folder, File, FolderOpen } from 'lucide-svelte'
+// TYPES
+import type { Compas } from '@oscd-plugins/core-ui-svelte'
+// VALIDATION
+import {
+	openSsdImportProblemDialog,
+	openSsdImportProblemDialogFromError
+} from '../ssd-validation'
+import { CreationPrerequisiteError } from '@/headless/domain/type-resolution'
+
+//====== INITIALIZATION ======//
+
+// states
+let selectedType = $state<Compas.AvailableFileType>()
+let selectedFilename = $state<string>()
+let selectedFileId = $state<string>()
+
+// derived
+const fileTypes = $derived(compasStore.getFileTypes())
+const filesList = $derived(
+	selectedType && compasStore.getFilesByType(selectedType)
+)
+
+//====== FUNCTIONS ======//
+
+function handleFileSelection(selectedFile: Compas.FileByType) {
+	selectedFileId = selectedFile.id
+	selectedFilename = selectedFile.name
+}
+
+async function loadSelectedFile() {
+	if (selectedType && selectedFileId && selectedFilename) {
+		const loadedFile = await compasStore.getFileByTypeAndId(
+			selectedType,
+			selectedFileId
+		)
+
+		if (!loadedFile) throw new Error('File not found')
+
+		try {
+			ssdImportStore.loadFromSSD(loadedFile, selectedFilename)
+		} catch (error) {
+			if (error instanceof CreationPrerequisiteError) {
+				await openSsdImportProblemDialogFromError(error, {
+					title: 'Cannot import SSD',
+					description:
+						'Resolve the following SSD problems before importing the file.'
+				})
+				return
+			}
+
+			await openSsdImportProblemDialog({
+				title: 'Cannot import SSD',
+				description: 'The selected SSD file could not be loaded.',
+				messages: [
+					error instanceof Error ? error.message : 'Unknown error'
+				]
+			})
+			return
+		}
+
+		await dialogStore.closeDialog()
+		resetSelectInputs()
+	}
+}
+
+function resetSelectInputs() {
+	selectedType = undefined
+	selectedFileId = undefined
+	selectedFilename = undefined
+}
+
+async function handleCloseDialog() {
+	await dialogStore.closeDialog()
+	resetSelectInputs()
+}
+
+//====== EFFECTS ======//
+$effect(() => {
+	if (!dialogStore.isOpen) resetSelectInputs()
+})
+</script>
+
+<section>
+	<header class="space-y-2 mb-5">
+		<h1 class="text-xl font-bold">Select a file</h1>
+		<p class="text-sm text-muted-foreground">Select an SSD file from CoMPAS to import bay types.</p>
+	</header>
+
+	<Separator.Root class="mb-5" />
+
+	<div class="overflow-x-hidden overflow-y-auto h-[50vh]">
+		{#if !selectedType}
+			<!-- TYPE SELECTION START -->
+			<div
+				in:fly={{ x: "-100%", opacity: 1, easing: cubicOut, duration: 500 }}
+				out:fly={{ x: "-100%", opacity: 1, easing: cubicOut, duration: 100 }}
+				class="flex flex-col space-y-2"
+			>
+				{#await fileTypes}
+
+				<LoaderCircle class="animate-spin self-center"/>
+
+				{:then currentFileTypes}
+
+					{#if currentFileTypes?.length}
+
+						{#each currentFileTypes as fileType}
+							<Button.Root class="w-full group flex justify-start" variant="ghost" onclick={() => { selectedType = fileType.code }}>
+								<Folder class="group-hover:hidden block"/>
+								<FolderOpen class="group-hover:block hidden"/>
+								<span>{fileType.description} ({fileType.code})</span>
+							</Button.Root>
+						{/each}
+
+					{/if}
+
+				{/await}
+			</div>
+			<!-- TYPE SELECTION END -->
+		{:else}
+			<!-- FILE SELECTION START -->
+			<div
+				in:fly={{ x: "100%", opacity: 1, easing: cubicOut, duration: 500 }}
+				out:fly={{ x: "100%", opacity: 1, easing: cubicOut, duration: 100 }}
+				class="flex flex-col space-y-2"
+			>
+				<Button.Root class={`"group flex justify-start items-center" ${selectedType ? "visible": "invisible"}`} variant="link" onclick={resetSelectInputs}>
+					<MoveLeft class="!size-5" /><span>Return to select a file type</span>
+				</Button.Root>
+				{#await filesList}
+
+				<LoaderCircle class="animate-spin self-center"/>
+
+				{:then currentFilesList}
+					{#if currentFilesList?.length}
+						{#each currentFilesList as file}
+							<Button.Root class="w-full group flex items-center justify-between" variant={selectedFileId === file.id ? 'secondary' : 'ghost'} onclick={() => handleFileSelection(file)}>
+								<div class="flex items-center space-x-2 min-w-0">
+									<File/>
+									<span class="truncate">{file.name}</span>
+								</div>
+								{#if file.label}<span>{file.label}</span>{/if}
+								<span>({file.version})</span>
+							</Button.Root>
+						{/each}
+					{:else}
+						<p class="text-muted-foreground self-center">No files available</p>
+					{/if}
+
+				{/await}
+			</div>
+			<!-- FILE SELECTION END -->
+		{/if}
+	</div>
+
+	<footer class="flex justify-end space-x-2 mt-5">
+		<Button.Root variant="outline" class="hover:bg-secondary hover:text-secondary-foreground" onclick={handleCloseDialog}>Cancel</Button.Root>
+		<Button.Root disabled={!selectedFileId} onclick={loadSelectedFile}>Select</Button.Root>
+	</footer>
+</section>

--- a/packages/plugins/type-distributor/src/ui/components/toolbar.svelte
+++ b/packages/plugins/type-distributor/src/ui/components/toolbar.svelte
@@ -2,7 +2,8 @@
 import {
 	Button,
 	pluginGlobalStore,
-	SelectWorkaround
+	SelectWorkaround,
+	compasStore
 } from '@oscd-plugins/core-ui-svelte'
 import {
 	assignedLNodesStore,
@@ -12,6 +13,7 @@ import {
 	ssdImportStore
 } from '@/headless/stores'
 import { handleImportSSD } from './ssd-validation'
+import { loadFromCompas } from '@/headless/import'
 
 const bays = $derived(
 	pluginGlobalStore.xmlDocument?.querySelectorAll(
@@ -65,6 +67,13 @@ const isBaySwitchLocked = $derived(
       />
     </div>
   {/if}
+  {#await compasStore.isCompasEnabled then isEnabled}
+    {#if isEnabled}
+      <Button.Root variant="ghost" onclick={() => loadFromCompas()}>
+        Load from Compas
+      </Button.Root>
+    {/if}
+  {/await}
   <Button.Root onclick={() => ssdImportStore.fileInput?.click()}>
     Import SSD File
   </Button.Root>


### PR DESCRIPTION
closes #795 

## Summary

- Add CoMPAS import dialog to Type Distributor (mirrors Type Designer's dialog, writes to `ssdImportStore`)
- Add `loadFromCompas()` helper that opens the dialog via `dialogStore`
- Show **Load from Compas** button in the toolbar only when the CoMPAS backend is reachable

Validation errors (`CreationPrerequisiteError` and generic errors) are handled inside the dialog using the existing `openSsdImportProblemDialog` helpers.